### PR TITLE
avoid crash on 'reload file'

### DIFF
--- a/src/org/osm2world/viewer/view/debug/DebugView.java
+++ b/src/org/osm2world/viewer/view/debug/DebugView.java
@@ -40,6 +40,7 @@ public abstract class DebugView {
 	private VectorXYZ cameraLookAt;
 	
 	private JOGLTarget target = null;
+	private boolean targetNeedsReset;
 	
 	public final void setConfiguration(Configuration config) {
 		
@@ -47,7 +48,7 @@ public abstract class DebugView {
 		
 		if (target != null) {
 			target.setConfiguration(config);
-			target.reset();
+			targetNeedsReset = true;
 		}
 		
 	}
@@ -58,10 +59,7 @@ public abstract class DebugView {
 		this.terrain = conversionResults.getTerrain();
 		this.eleData = conversionResults.getEleData();
 		
-		if (target != null) {
-			target.reset();
-		}
-		
+		targetNeedsReset = true;
 	}
 	
 	/**
@@ -96,7 +94,10 @@ public abstract class DebugView {
 				target = new JOGLTarget(gl, new JOGLRenderingParameters(
 						null, false, true), null);
 				target.setConfiguration(config);
+			} else if (targetNeedsReset){
+				target.reset();
 			}
+			targetNeedsReset = false;
 			
 			boolean viewChanged = !camera.getPos().equals(this.cameraPos)
 					|| !camera.getUp().equals(this.cameraUp)


### PR DESCRIPTION
At least on my driver calling glDeleteBuffer (via target reset) from OpenOSMThread crashes constantly. So I've added a flag to reset target on next run of 'renderTo' instead. Not sure if this is correct. It would probably be better to clear all views before reloading, but then I'm really not into threads observing each other :)

```
Thread [OpenOSMThread] (Suspended (breakpoint at line 271 in JOGLRendererVBO$VBOData))  
    JOGLRendererVBO$VBODataFloat(JOGLRendererVBO$VBOData<BufferT>).delete() line: 271   
    JOGLRendererVBO.freeResources() line: 555   
    JOGLTarget.reset() line: 99 
    TerrainView(DebugView).setConfiguration(Configuration) line: 51 
    ToggleDebugViewAction.update(Observable, Object) line: 67   
    Data(Observable).notifyObservers(Object) line: 142  
    Data(Observable).notifyObservers() line: 98 
    Data.loadOSMFile(File, ElevationCalculator, boolean, ConversionFacade$ProgressListener) line: 78    
    OpenOSMAction$OpenOSMThread.run() line: 151 
```
