### PR TITLE
Add support for the spelling "gray" alongside "grey"

### DIFF
--- a/src/org/osm2world/core/world/modules/BuildingModule.java
+++ b/src/org/osm2world/core/world/modules/BuildingModule.java
@@ -868,7 +868,7 @@ public class BuildingModule extends ConfigurableWorldModule {
 					color = new Color(240, 240, 240);
 				} else if ("black".equals(colorString)) {
 					color = new Color(76, 76, 76);
-				} else if ("grey".equals(colorString)) {
+				} else if ("grey".equals(colorString) || "gray".equals(colorString)) {
 					color = new Color(100, 100, 100);
 				} else if ("red".equals(colorString)) {
 					if (roof) {


### PR DESCRIPTION
In OSM tagging, both variants are used considerably.
In the CSS 3 Standard, both variants are accepted, where _gray_ is a basic color keyword and _grey_ is an extended color keyword. (see http://www.w3.org/TR/css3-color/#svg-color).