### PR TITLE
IllegalStateException preventing some surfaces from being drawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 .classpath
 .project
 doc/javadoc
+/nbproject/private/
+/dist/

--- a/src/org/osm2world/core/math/algorithms/Poly2TriTriangulationUtil.java
+++ b/src/org/osm2world/core/math/algorithms/Poly2TriTriangulationUtil.java
@@ -72,6 +72,7 @@ public final class Poly2TriTriangulationUtil {
 			for (VectorXZ knownVector : knownVectors) {
 				if (knownVector.distanceTo(filteredPoint) < 0.2) {
 					filteredPointsIterator.remove();
+					break;
 				}
 			}
 		}

--- a/src/org/osm2world/core/world/modules/BarrierModule.java
+++ b/src/org/osm2world/core/world/modules/BarrierModule.java
@@ -172,6 +172,7 @@ public class BarrierModule extends AbstractModule {
 		private static Material getMaterial(TagGroup tags) {
 			if ("gabion".equals(tags.getValue("wall"))) {
 				return Materials.WALL_GABION;
+			}
 			else if ( tags.containsKey("material") ) {              
 				return Materials.getMaterial(tags.getValue("material").toUpperCase());
 			} else {

--- a/src/org/osm2world/core/world/modules/BarrierModule.java
+++ b/src/org/osm2world/core/world/modules/BarrierModule.java
@@ -172,6 +172,8 @@ public class BarrierModule extends AbstractModule {
 		private static Material getMaterial(TagGroup tags) {
 			if ("gabion".equals(tags.getValue("wall"))) {
 				return Materials.WALL_GABION;
+			else if ( tags.containsKey("material") ) {              
+				return Materials.getMaterial(tags.getValue("material").toUpperCase());
 			} else {
 				return Materials.WALL_DEFAULT;
 			}


### PR DESCRIPTION
The method triangulate fails with a IllegalStateException when it
encounters multiple points close together and attempts to filter them
out.