### PR TITLE
Remove warning by deleting unused import

### DIFF
--- a/src/org/osm2world/console/Output.java
+++ b/src/org/osm2world/console/Output.java
@@ -42,8 +42,6 @@ import org.osm2world.core.target.obj.ObjWriter;
 import org.osm2world.core.target.povray.POVRayWriter;
 import org.osm2world.core.util.functions.DefaultFactory;
 
-import sun.awt.SunToolkit.InfiniteLoop;
-
 public final class Output {
 
 	private Output() {}


### PR DESCRIPTION
This will remove the following warning:

_src/org/osm2world/console/Output.java:45: warning: SunToolkit is internal proprietary API and may be removed in a future release_
