### PR TITLE
Svg support and font shipping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,45 @@
 			<version>2.1.1</version>
 		</dependency>
 
+		<!-- Batik library dependencies -->
+
+		<dependency>
+    		<groupId>org.apache.xmlgraphics</groupId>
+    		<artifactId>batik-transcoder</artifactId>
+    		<version>1.11</version>
+		</dependency>
+
+		<dependency>
+    		<groupId>org.apache.xmlgraphics</groupId>
+    		<artifactId>batik-rasterizer</artifactId>
+    		<version>1.11</version>
+		</dependency>
+
+		<dependency>
+    		<groupId>org.apache.xmlgraphics</groupId>
+    		<artifactId>batik-slideshow</artifactId>
+    		<version>1.11</version>
+		</dependency>
+
+		<dependency>
+		    <groupId>org.apache.xmlgraphics</groupId>
+		    <artifactId>batik-squiggle</artifactId>
+		    <version>1.11</version>
+		</dependency>
+
+		<dependency>
+		    <groupId>org.apache.xmlgraphics</groupId>
+		    <artifactId>batik-svgpp</artifactId>
+		    <version>1.11</version>
+		</dependency>
+
+		<dependency>
+		    <groupId>org.apache.xmlgraphics</groupId>
+		    <artifactId>batik-ttf2svg</artifactId>
+		    <version>1.11</version>
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/osm2world/console/OSM2World.java
+++ b/src/main/java/org/osm2world/console/OSM2World.java
@@ -19,6 +19,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.osm2world.console.CLIArgumentsUtil.ProgramMode;
 import org.osm2world.core.GlobalValues;
 import org.osm2world.viewer.view.ViewerFrame;
+import org.osm2world.core.util.ConfigUtil;
 
 import com.lexicalscope.jewel.cli.ArgumentValidationException;
 import com.lexicalscope.jewel.cli.CliFactory;
@@ -167,6 +168,8 @@ public class OSM2World {
 				fileConfig.setListDelimiter(';');
 				fileConfig.load(configFile);
 				config = fileConfig;
+				ConfigUtil.parseFonts(config);
+
 			} catch (ConfigurationException e) {
 				System.err.println("could not read config, ignoring it: ");
 				System.err.println(e);

--- a/src/main/java/org/osm2world/core/util/ConfigUtil.java
+++ b/src/main/java/org/osm2world/core/util/ConfigUtil.java
@@ -1,8 +1,15 @@
 package org.osm2world.core.util;
 
 import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.configuration.Configuration;
 
 /**
  * utility class for parsing configuration values
@@ -41,13 +48,13 @@ final public class ConfigUtil {
 		"^hsv\\s*\\(\\s*(\\d{1,3})\\s*," +
 			"\\s*(\\d{1,3})\\s*%\\s*," +
 			"\\s*(\\d{1,3})\\s*%\\s*\\)");
-
+		
 	/**
 	 * parses colors that are given as a color scheme identifier
 	 * with a value tuple in brackets.
-	 *
+	 * 
 	 * Currently only supports hsv.
-	 *
+	 * 
 	 * @return color; null on parsing errors
 	 */
 	public static final Color parseColorTuple(String colorString) {
@@ -72,6 +79,37 @@ final public class ConfigUtil {
 
 		return null;
 
+	}
+
+	/**
+	 * Registers the fonts that exist in the directory specified
+	 * by the "fontDirectory" key in the configuration file.
+	 * The respective fonts can then be used in Font object constructors.
+	 */
+	public static void parseFonts(Configuration config) {
+
+		if(!config.containsKey("fontDirectory")) return;
+
+		String directoryName = config.getString("fontDirectory");
+		File fontDir = new File(directoryName);
+
+		if(!fontDir.isDirectory()) return;
+
+		GraphicsEnvironment gEnv = GraphicsEnvironment.getLocalGraphicsEnvironment();
+
+		File[] listOfFiles = fontDir.listFiles();
+
+		for (File file : listOfFiles) {
+		    if (file.isFile()) {
+
+		    	try {
+					gEnv.registerFont(Font.createFont(Font.TRUETYPE_FONT, file));
+				} catch (FontFormatException | IOException e) {
+					System.err.println("Could not register font "+file.getName());
+					e.printStackTrace();
+				}
+		    }
+		}
 	}
 
 }

--- a/src/main/java/org/osm2world/viewer/control/actions/ReloadOSMAction.java
+++ b/src/main/java/org/osm2world/viewer/control/actions/ReloadOSMAction.java
@@ -15,6 +15,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.osm2world.viewer.model.Data;
 import org.osm2world.viewer.model.RenderOptions;
 import org.osm2world.viewer.view.ViewerFrame;
+import org.osm2world.core.util.ConfigUtil;
 
 /**
  * reloads the previously opened OSM file
@@ -62,6 +63,7 @@ public class ReloadOSMAction extends AbstractAction implements Observer {
 				fileConfig.setListDelimiter(';');
 				fileConfig.load(configFile);
 				data.setConfig(fileConfig);
+				ConfigUtil.parseFonts(fileConfig);
 
 			} catch (ConfigurationException e) {
 
@@ -81,7 +83,7 @@ public class ReloadOSMAction extends AbstractAction implements Observer {
 
 		new OpenOSMAction(viewerFrame, data, renderOptions)
 				.openOSMFile(data.getOsmFile(), false);
-
+		
 	}
 
 	@Override


### PR DESCRIPTION
- Whenever a .svg image file is used as a material texture, it will be converted into a .png and this png will be used instead. Batik library dependencies are added for this task.

- Font files that reside in a ./fonts directory in the project root directory, will be parsed and registered for use in the application. They will be available to use by their name in a Font constructor.