### PR TITLE
Svg support and font shipping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,18 @@
 			<version>2.1.1</version>
 		</dependency>
 
+		<dependency>
+    		<groupId>org.apache.xmlgraphics</groupId>
+    		<artifactId>batik-transcoder</artifactId>
+    		<version>1.11</version>
+		</dependency>
+
+		<dependency>
+    		<groupId>org.apache.xmlgraphics</groupId>
+    		<artifactId>batik-rasterizer</artifactId>
+    		<version>1.11</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/osm2world/console/OSM2World.java
+++ b/src/main/java/org/osm2world/console/OSM2World.java
@@ -19,6 +19,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.osm2world.console.CLIArgumentsUtil.ProgramMode;
 import org.osm2world.core.GlobalValues;
 import org.osm2world.viewer.view.ViewerFrame;
+import org.osm2world.core.util.ConfigUtil;
 
 import com.lexicalscope.jewel.cli.ArgumentValidationException;
 import com.lexicalscope.jewel.cli.CliFactory;
@@ -167,6 +168,8 @@ public class OSM2World {
 				fileConfig.setListDelimiter(';');
 				fileConfig.load(configFile);
 				config = fileConfig;
+				ConfigUtil.parseFonts(config);
+
 			} catch (ConfigurationException e) {
 				System.err.println("could not read config, ignoring it: ");
 				System.err.println(e);

--- a/src/main/java/org/osm2world/core/target/common/ImageTextureData.java
+++ b/src/main/java/org/osm2world/core/target/common/ImageTextureData.java
@@ -35,11 +35,13 @@ public class ImageTextureData extends TextureData {
 	@Override
 	public File getFile() {
 
-		if(this.file.getName().endsWith(".svg") && this.convertedToPng == null) {
-			convertedToPng = SVG2PNG(this.file);
-		}
+		if(this.file.getName().endsWith(".svg")) {
 
-		if(this.file.getName().endsWith(".svg") && this.convertedToPng != null) {
+			if(this.convertedToPng==null) {
+
+				convertedToPng = SVG2PNG(this.file);
+			}
+
 			return convertedToPng;
 		}
 
@@ -64,31 +66,30 @@ public class ImageTextureData extends TextureData {
 		String svgURI = svg.toURI().toString();
 		TranscoderInput input = new TranscoderInput(svgURI);
 
-		File outputFile = null;
-
 		try {
+
+			File outputFile = null;
 
 			//create a temporary file in the default temporary-file directory
 			outputFile = File.createTempFile(prefix, ".png");
 			outputFile.deleteOnExit();
 
-			OutputStream ostream = new FileOutputStream(outputFile);
+			try(OutputStream ostream = new FileOutputStream(outputFile)) {
 
-			TranscoderOutput output = new TranscoderOutput(ostream);
+				TranscoderOutput output = new TranscoderOutput(ostream);
 
-			//save the image.
-			t.transcode(input, output);
+				//save the image.
+				t.transcode(input, output);
 
-			//clear and close the stream
-			ostream.flush();
-			ostream.close();
+				ostream.flush();
+			}
+
+			return outputFile;
 
 		} catch (IOException | TranscoderException e) {
 
 			throw new RuntimeException(e);
 		}
-
-		return outputFile;
 	}
 
 	@Override

--- a/src/main/java/org/osm2world/core/util/ConfigUtil.java
+++ b/src/main/java/org/osm2world/core/util/ConfigUtil.java
@@ -1,8 +1,15 @@
 package org.osm2world.core.util;
 
 import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.configuration.Configuration;
 
 /**
  * utility class for parsing configuration values
@@ -41,13 +48,13 @@ final public class ConfigUtil {
 		"^hsv\\s*\\(\\s*(\\d{1,3})\\s*," +
 			"\\s*(\\d{1,3})\\s*%\\s*," +
 			"\\s*(\\d{1,3})\\s*%\\s*\\)");
-
+		
 	/**
 	 * parses colors that are given as a color scheme identifier
 	 * with a value tuple in brackets.
-	 *
+	 * 
 	 * Currently only supports hsv.
-	 *
+	 * 
 	 * @return color; null on parsing errors
 	 */
 	public static final Color parseColorTuple(String colorString) {
@@ -72,6 +79,37 @@ final public class ConfigUtil {
 
 		return null;
 
+	}
+
+	/**
+	 * Registers the fonts that exist in the directory specified
+	 * by the "fontDirectory" key in the configuration file.
+	 * The respective fonts can then be used in Font object constructors.
+	 */
+	public static void parseFonts(Configuration config) {
+
+		if(!config.containsKey("fontDirectory")) return;
+
+		String directoryName = config.getString("fontDirectory");
+		File fontDir = new File(directoryName);
+
+		if(!fontDir.isDirectory()) return;
+
+		GraphicsEnvironment gEnv = GraphicsEnvironment.getLocalGraphicsEnvironment();
+
+		File[] listOfFiles = fontDir.listFiles();
+
+		for (File file : listOfFiles) {
+		    if (file.isFile()) {
+
+		    	try {
+					gEnv.registerFont(Font.createFont(Font.TRUETYPE_FONT, file));
+				} catch (FontFormatException | IOException e) {
+					System.err.println("Could not register font "+file.getName());
+					e.printStackTrace();
+				}
+		    }
+		}
 	}
 
 }

--- a/src/main/java/org/osm2world/viewer/control/actions/ReloadOSMAction.java
+++ b/src/main/java/org/osm2world/viewer/control/actions/ReloadOSMAction.java
@@ -15,6 +15,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.osm2world.viewer.model.Data;
 import org.osm2world.viewer.model.RenderOptions;
 import org.osm2world.viewer.view.ViewerFrame;
+import org.osm2world.core.util.ConfigUtil;
 
 /**
  * reloads the previously opened OSM file
@@ -62,6 +63,7 @@ public class ReloadOSMAction extends AbstractAction implements Observer {
 				fileConfig.setListDelimiter(';');
 				fileConfig.load(configFile);
 				data.setConfig(fileConfig);
+				ConfigUtil.parseFonts(fileConfig);
 
 			} catch (ConfigurationException e) {
 
@@ -81,7 +83,7 @@ public class ReloadOSMAction extends AbstractAction implements Observer {
 
 		new OpenOSMAction(viewerFrame, data, renderOptions)
 				.openOSMFile(data.getOsmFile(), false);
-
+		
 	}
 
 	@Override


### PR DESCRIPTION
- Whenever an .svg file is configured as a material texture, it is converted to .png and this .png is used instead. RuntimeException is thrown if the conversion fails at any point.

- Font files can now be placed in a new directory inside the project. This directory's path must be configured in the .properties file in a manner similar to: "fontDirectory = ./fonts" (for a directory named "fonts" and located in the project's root dir). These fonts are registered into the application and can be used by their name in Font constructors.