### PR TITLE
Place windows and doors and give indoor walls thickness

### DIFF
--- a/src/main/java/org/osm2world/core/map_elevation/creation/SRTMTile.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/SRTMTile.java
@@ -3,6 +3,7 @@ package org.osm2world.core.map_elevation.creation;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
@@ -43,7 +44,7 @@ class SRTMTile {
 			ByteBuffer bb = ByteBuffer.allocateDirect((int) fc.size());
 			while (bb.remaining() > 0) fc.read(bb);
 
-			bb.flip();
+			((Buffer)bb).flip();
 
 			// choose the right endianness
 			return bb.order(ByteOrder.BIG_ENDIAN).asShortBuffer();

--- a/src/main/java/org/osm2world/core/math/AxisAlignedRectangleXZ.java
+++ b/src/main/java/org/osm2world/core/math/AxisAlignedRectangleXZ.java
@@ -49,6 +49,26 @@ public class AxisAlignedRectangleXZ implements SimplePolygonShapeXZ {
 
 	}
 
+	/**
+	 * @param boundedObjects  must contain at least one object
+	 */
+	public static AxisAlignedRectangleXZ bboxUnion(Collection<? extends BoundedObject> boundedObjects) {
+
+		assert (!boundedObjects.isEmpty());
+
+		double minX = Double.POSITIVE_INFINITY, minZ = Double.POSITIVE_INFINITY;
+		double maxX = Double.NEGATIVE_INFINITY, maxZ = Double.NEGATIVE_INFINITY;
+
+		for (BoundedObject boundedObject : boundedObjects) {
+			AxisAlignedRectangleXZ bbox = boundedObject.boundingBox();
+			minX = min(minX, bbox.minX); minZ = min(minZ, bbox.minZ);
+			maxX = max(maxX, bbox.maxX); maxZ = max(maxZ, bbox.maxZ);
+		}
+
+		return new AxisAlignedRectangleXZ(minX, minZ, maxX, maxZ);
+
+	}
+
 	public double sizeX() { return maxX - minX; }
 	public double sizeZ() { return maxZ - minZ; }
 

--- a/src/main/java/org/osm2world/core/math/FaceXYZ.java
+++ b/src/main/java/org/osm2world/core/math/FaceXYZ.java
@@ -1,0 +1,54 @@
+package org.osm2world.core.math;
+
+import static java.lang.Math.abs;
+
+import java.util.List;
+
+/**
+ * a simple polygon where all vertices are in the same plane
+ */
+public class FaceXYZ extends PolygonXYZ implements FlatSimplePolygonShapeXYZ {
+
+	private final VectorXYZ normal;
+
+	public FaceXYZ(List<VectorXYZ> vertexLoop) {
+
+		super(vertexLoop);
+
+		/* find three polygon vertices that are not collinear (for normal vector calculation) */
+
+		final VectorXYZ v1 = vertexLoop.get(0);
+		final VectorXYZ v2 = vertexLoop.get(1);
+
+		VectorXYZ v3 = null;
+		for (int i = 2; i < vertexLoop.size() - 1; i++) {
+			VectorXYZ vTest = vertexLoop.get(i);
+			if (vTest.subtract(v1).angleTo(vTest.subtract(v2)) > 0.001) {
+				v3 = vTest;
+			}
+		}
+
+		if (v3 == null) {
+			throw new InvalidGeometryException("Points of face are collinear: " + vertexLoop);
+		}
+
+		/* calculate the normal vector of the triangle defined by these 3 points */
+
+		normal = new TriangleXYZ(v1, v2, v3).getNormal();
+
+		/* check that the vertices lie in a plane, throw exception otherwise */
+
+		for (VectorXYZ v : vertexLoop) {
+			if (abs(rotateToOrFromFacePlane(v, true).y - getCenter().y) > 0.01) {
+				throw new InvalidGeometryException("face vertices do not lie in a plane");
+			}
+		}
+
+	}
+
+	@Override
+	public VectorXYZ getNormal() {
+		return normal;
+	}
+
+}

--- a/src/main/java/org/osm2world/core/math/FlatSimplePolygonShapeXYZ.java
+++ b/src/main/java/org/osm2world/core/math/FlatSimplePolygonShapeXYZ.java
@@ -1,0 +1,113 @@
+package org.osm2world.core.math;
+
+import static java.lang.Math.PI;
+import static java.util.stream.Collectors.toList;
+import static org.osm2world.core.math.VectorXYZ.*;
+
+import java.util.List;
+
+/**
+ * a simple 3D polygon where all vertices are in the same plane.
+ * {@link FaceXYZ} is the most general implementation.
+ */
+public interface FlatSimplePolygonShapeXYZ {
+
+	/**
+	 * returns the polygon's vertices. First and last vertex are equal.
+	 */
+	public List<VectorXYZ> getVertexLoop();
+
+	/**
+	 * returns the polygon's vertices.
+	 * Unlike {@link #getVertexLoop()}, there is no duplication
+	 * of the first/last vertex.
+	 */
+	public List<VectorXYZ> getVertices();
+
+	/** returns the normalized normal vector. The vector points "up" for a counterclockwise polygon. */
+	public VectorXYZ getNormal();
+
+	/**
+	 * returns the average of all vertex coordinates.
+	 * The result is not necessarily contained by this polygon.
+	 * @see SimplePolygonXZ#getCenter()
+	 */
+	default public VectorXYZ getCenter() {
+		double x=0, y=0, z=0;
+		int numberVertices = getVertices().size();
+		for (VectorXYZ vertex : getVertices()) {
+			x += vertex.x / numberVertices;
+			y += vertex.y / numberVertices;
+			z += vertex.z / numberVertices;
+			/* single division per coordinate after loop would be faster,
+			 * but might cause numbers to get too large */
+		}
+		return new VectorXYZ(x, y, z);
+	}
+
+	/** returns the closest point on this face to a given point in 3D space */
+	default public VectorXYZ closestPoint(VectorXYZ v) {
+
+		VectorXZ pointInPlane = toFacePlane(v);
+		SimplePolygonXZ polygonInPlane = toFacePlane(this);
+
+		VectorXZ closestPointInPlane = polygonInPlane.closestPoint(pointInPlane);
+
+		return fromFacePlane(closestPointInPlane);
+
+	}
+
+	default public double distanceTo(VectorXYZ p) {
+		return closestPoint(p).distanceTo(p);
+	}
+
+	/* TODO: make private in Java 9 */
+	default VectorXZ toFacePlane(VectorXYZ v) {
+		return rotateToOrFromFacePlane(v, true).xz();
+	}
+
+	/* TODO: make private in Java 9 */
+	default SimplePolygonXZ toFacePlane(FlatSimplePolygonShapeXYZ p) {
+		List<VectorXZ> xzLoop = p.getVertexLoop().stream().map(v -> toFacePlane(v)).collect(toList());
+		return new SimplePolygonXZ(xzLoop);
+	}
+
+	/* TODO: make private in Java 9 */
+	default VectorXYZ fromFacePlane(VectorXZ v) {
+		return rotateToOrFromFacePlane(v.xyz(getCenter().y), false);
+	}
+
+	/* TODO: make private in Java 9 */
+	default FaceXYZ fromFacePlane(SimplePolygonXZ p) {
+		List<VectorXYZ> xyzLoop = p.getVertexList().stream().map(v -> fromFacePlane(v)).collect(toList());
+		return new FaceXYZ(xyzLoop);
+	}
+
+	/* TODO: make private in Java 9 */
+	default VectorXYZ rotateToOrFromFacePlane(VectorXYZ v, boolean to) {
+
+		VectorXYZ faceNormal = getNormal();
+
+		if (faceNormal.distanceTo(Y_UNIT) < 0.001) {
+
+			return v;
+
+		} else if (faceNormal.distanceTo(Y_UNIT.invert()) < 0.001) {
+
+			return v.rotateVec(PI, getCenter(), Z_UNIT);
+
+		} else {
+
+			VectorXYZ xzNormal = Y_UNIT;
+			VectorXYZ rotAxis = faceNormal.cross(xzNormal);
+			VectorXYZ rotOrigin = getCenter();
+
+			double angle = faceNormal.angleTo(xzNormal);
+
+			return v.rotateVec(to ? angle : -angle, rotOrigin, rotAxis);
+
+		}
+
+	}
+
+}

--- a/src/main/java/org/osm2world/core/math/GeometryUtil.java
+++ b/src/main/java/org/osm2world/core/math/GeometryUtil.java
@@ -1,6 +1,7 @@
 package org.osm2world.core.math;
 
 import static java.lang.Math.sqrt;
+import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static org.osm2world.core.math.VectorXZ.*;
 import static org.osm2world.core.math.algorithms.CAGUtil.subtractPolygons;
@@ -21,6 +22,24 @@ public final class GeometryUtil {
 
 	/** prevents instantiation */
 	private GeometryUtil() { }
+
+	/**
+	 * returns the list itself if the last element of the list equals the first;
+	 * otherwise, returns a list that's the same except with the first element appended to the end.
+	 */
+	public static final <T> List<T> closeLoop(List<T> list) {
+		if (!list.get(0).equals(list.get(list.size() - 1))) {
+			list = new ArrayList<>(list);
+			list.add(list.get(0));
+		}
+		return list;
+	}
+
+	/** vararg variant of {@link #closeLoop(List)} */
+	@SafeVarargs
+	public static final <T> List<T> closeLoop(T... list) {
+		return closeLoop(asList(list));
+	}
 
 	public static final List<TriangleXYZ> trianglesFromVertexList(
 			List<? extends VectorXYZ> vs) {

--- a/src/main/java/org/osm2world/core/math/PolygonXYZ.java
+++ b/src/main/java/org/osm2world/core/math/PolygonXYZ.java
@@ -1,6 +1,7 @@
 package org.osm2world.core.math;
 
 import static java.util.stream.Collectors.toList;
+import static org.osm2world.core.math.AxisAlignedRectangleXZ.bbox;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -9,10 +10,10 @@ import java.util.List;
 /**
  * a three-dimensional polygon
  */
-public class PolygonXYZ {
+public class PolygonXYZ implements BoundedObject {
 
 	/** polygon vertices; first and last vertex are equal */
-	private final List<VectorXYZ> vertexLoop;
+	protected final List<VectorXYZ> vertexLoop;
 
 	/**
 	 * @param vertexLoop  vertices defining the polygon;
@@ -101,8 +102,18 @@ public class PolygonXYZ {
 		return new PolygonXYZ(newVertexLoop);
 	}
 
+	@Override
+	public AxisAlignedRectangleXZ boundingBox() {
+		return bbox(vertexLoop);
+	}
+
 	public PolygonXYZ add(VectorXYZ v) {
 		return new PolygonXYZ(getVertexLoop().stream().map(v::add).collect(toList()));
+	}
+
+	@Override
+	public String toString() {
+		return vertexLoop.toString();
 	}
 
 }

--- a/src/main/java/org/osm2world/core/math/SimplePolygonXZ.java
+++ b/src/main/java/org/osm2world/core/math/SimplePolygonXZ.java
@@ -121,6 +121,18 @@ public class SimplePolygonXZ implements SimplePolygonShapeXZ {
 
 	}
 
+	/**
+	 * returns the point on this polygon that is closest to a given point.
+	 * For points within this polygon, this returns the point itself.
+	 */
+	public VectorXZ closestPoint(VectorXZ point) {
+		if (this.contains(point)) {
+			return point;
+		} else {
+			return getClosestSegment(point).closestPoint(point);
+		}
+	}
+
 	private void calculateArea() {
 		this.signedArea = calculateSignedArea(vertexLoop);
 		this.area = Math.abs(signedArea);

--- a/src/main/java/org/osm2world/core/math/TriangleXYZ.java
+++ b/src/main/java/org/osm2world/core/math/TriangleXYZ.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
-public class TriangleXYZ {
+public class TriangleXYZ implements FlatSimplePolygonShapeXYZ {
 
 	public final VectorXYZ v1, v2, v3;
 
@@ -14,15 +14,22 @@ public class TriangleXYZ {
 		this.v3 = v3;
 	}
 
+	@Override
 	public List<VectorXYZ> getVertices() {
 		return ImmutableList.of(v1, v2, v3);
 	}
 
+	@Override
+	public List<VectorXYZ> getVertexLoop() {
+		return ImmutableList.of(v1, v2, v3, v1);
+	}
+
 	/**
-	 * returns the normalized normal vector of this triangle
+	 * returns the normalized normal vector of this triangle.
+	 * Points "up" based on assumption that this is a counterclockwise triangle.
 	 */
+	@Override
 	public VectorXYZ getNormal() {
-		//TODO: account for clockwise vs. counterclockwise
 		return v2.subtract(v1).crossNormalized(v2.subtract(v3));
 	}
 

--- a/src/main/java/org/osm2world/core/math/VectorXYZ.java
+++ b/src/main/java/org/osm2world/core/math/VectorXYZ.java
@@ -1,6 +1,6 @@
 package org.osm2world.core.math;
 
-import static java.lang.Math.sqrt;
+import static java.lang.Math.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -184,11 +184,10 @@ public class VectorXYZ implements Vector3D, BoundedObject {
 	}
 
 	/**
-	 * calculates the angle between this vector and other,
-	 * but only if both are normalized!
+	 * calculates the angle between this vector and other
 	 */
 	public double angleTo(VectorXYZ other) {
-		return Math.acos(this.dot(other));
+		return acos(this.normalize().dot(other.normalize()));
 	}
 
 	public double distanceTo(VectorXYZ other) {

--- a/src/main/java/org/osm2world/core/math/algorithms/Earcut4JTriangulationUtil.java
+++ b/src/main/java/org/osm2world/core/math/algorithms/Earcut4JTriangulationUtil.java
@@ -4,9 +4,7 @@ import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.osm2world.core.math.TriangleXZ;
 import org.osm2world.core.math.VectorXZ;
@@ -15,6 +13,8 @@ import org.osm2world.core.math.shapes.SimplePolygonShapeXZ;
 import com.google.common.primitives.Ints;
 
 import earcut4j.Earcut;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 /**
  * uses the earcut4j library for triangulation.
@@ -70,7 +70,7 @@ public class Earcut4JTriangulationUtil {
 		/* points are simulated as holes with 2 almost identical points which are merged back together later.
 		 * (Single-point holes get a special treatment by earcut4j and may not be contained in the result at all.) */
 
-		Map<Integer, Integer> mergeIndexMap = new HashMap<>();
+		TIntIntMap mergeIndexMap = new TIntIntHashMap(points.size() * 2,  0.75f, -1, -1);
 
 		for (VectorXZ point : points) {
 			holeIndices.add(dataIndex);
@@ -90,9 +90,9 @@ public class Earcut4JTriangulationUtil {
 		 * (this also requires checking triangles for duplicate indices later) */
 
 		for (int i = 0; i < rawResult.size(); i++) {
-			Integer newIndex = mergeIndexMap.get(rawResult.get(i));
-			if (newIndex != null) {
-				rawResult.set(i, newIndex);
+			Integer rawValue = rawResult.get(i);
+			if (mergeIndexMap.containsKey(rawValue)) {
+				rawResult.set(i, mergeIndexMap.get(rawValue));
 			}
 		}
 

--- a/src/main/java/org/osm2world/core/math/shapes/PolylineShapeXZ.java
+++ b/src/main/java/org/osm2world/core/math/shapes/PolylineShapeXZ.java
@@ -38,7 +38,7 @@ public interface PolylineShapeXZ extends ShapeXZ {
 		List<VectorXZ> vertices = getVertexList();
 
 		// how far a point can be from a segment of this polyline and still be considered "on" it
-		final double IS_ON_TOLERANCE = 0.02; //1e-4;
+		final double IS_ON_TOLERANCE = 1e-4;
 
 		/* if the point is a vertex of this polyline ... */
 

--- a/src/main/java/org/osm2world/core/math/shapes/PolylineShapeXZ.java
+++ b/src/main/java/org/osm2world/core/math/shapes/PolylineShapeXZ.java
@@ -38,7 +38,7 @@ public interface PolylineShapeXZ extends ShapeXZ {
 		List<VectorXZ> vertices = getVertexList();
 
 		// how far a point can be from a segment of this polyline and still be considered "on" it
-		final double IS_ON_TOLERANCE = 1e-4;
+		final double IS_ON_TOLERANCE = 0.02; //1e-4;
 
 		/* if the point is a vertex of this polyline ... */
 

--- a/src/main/java/org/osm2world/core/math/shapes/ShapeXZ.java
+++ b/src/main/java/org/osm2world/core/math/shapes/ShapeXZ.java
@@ -1,5 +1,6 @@
 package org.osm2world.core.math.shapes;
 
+import static java.util.stream.Collectors.toList;
 import static org.osm2world.core.math.AxisAlignedRectangleXZ.bbox;
 
 import java.util.ArrayList;
@@ -39,6 +40,18 @@ public interface ShapeXZ extends BoundedObject {
 	@Override
 	default AxisAlignedRectangleXZ boundingBox() {
 		return bbox(getVertexList());
+	}
+
+	/**
+	 * returns a rotated version of this shape. Rotation is around the origin.
+	 *
+	 * @param angleRad  clockwise rotation angle in radians
+	 */
+	public default ShapeXZ rotatedCW(double angleRad) {
+		List<VectorXZ> rotatedVertexList = getVertexList().stream()
+				.map(v -> v.rotate(angleRad))
+				.collect(toList());
+		return () -> rotatedVertexList;
 	}
 
 }

--- a/src/main/java/org/osm2world/core/math/shapes/SimplePolygonShapeXZ.java
+++ b/src/main/java/org/osm2world/core/math/shapes/SimplePolygonShapeXZ.java
@@ -173,4 +173,12 @@ public interface SimplePolygonShapeXZ extends SimpleClosedShapeXZ, PolygonShapeX
 
 	}
 
+	@Override
+	default SimplePolygonShapeXZ rotatedCW(double angleRad) {
+		List<VectorXZ> rotatedVertexList = getVertexList().stream()
+				.map(v -> v.rotate(angleRad))
+				.collect(toList());
+		return new SimplePolygonXZ(rotatedVertexList);
+	}
+
 }

--- a/src/main/java/org/osm2world/core/osm/ruleset/HardcodedRuleset.java
+++ b/src/main/java/org/osm2world/core/osm/ruleset/HardcodedRuleset.java
@@ -42,6 +42,7 @@ public class HardcodedRuleset implements Ruleset {
 		areaTags.add(new Tag("indoor", "corridor"));
 
 		areaKeys.add("area:highway");
+		areaKeys.add("bridge:support");
 		areaKeys.add("building");
 		areaKeys.add("building:part");
 		areaKeys.add("golf");

--- a/src/main/java/org/osm2world/core/target/common/material/Materials.java
+++ b/src/main/java/org/osm2world/core/target/common/material/Materials.java
@@ -146,6 +146,9 @@ public final class Materials {
 	public static final ConfMaterial GARAGE_DOOR =
 			new ConfMaterial(Interpolation.FLAT, WHITE);
 
+	public static final ConfMaterial GLASS_TRANSPARENT =
+			new ConfMaterial(Interpolation.FLAT, new Color(0.9f, 0.9f, 0.9f), Transparency.TRUE, Collections.emptyList());
+
 	public static final ConfMaterial WALL_GABION =
 		new ConfMaterial(Interpolation.FLAT, Color.GRAY);
 

--- a/src/main/java/org/osm2world/core/world/attachment/AttachmentConnector.java
+++ b/src/main/java/org/osm2world/core/world/attachment/AttachmentConnector.java
@@ -1,0 +1,94 @@
+package org.osm2world.core.world.attachment;
+
+import java.util.List;
+
+import org.osm2world.core.math.VectorXYZ;
+import org.osm2world.core.math.VectorXZ;
+import org.osm2world.core.world.data.WorldObject;
+
+/**
+ * a connector that can be attached to an {@link AttachmentSurface}
+ */
+public class AttachmentConnector {
+
+	/** default value for {@link #maxDistanceXZ} */
+	private static final double DEFAULT_MAX_DISTANCE_XZ = 10;
+
+	public final List<String> compatibleSurfaceTypes;
+
+	public final VectorXYZ originalPos;
+
+	/** the object that has created this connector, and which is looking for a surface */
+	public final WorldObject object;
+
+	/**
+	 * the maximum horizontal distance a surface can be from the initial position and still allow attachment.
+	 * May be set to 0 in certain cases (e.g. for indoor mapping, when only vertical movement is desired).
+	 */
+	public final double maxDistanceXZ;
+
+	/** preferred height above the surface's {@link AttachmentSurface#getBaseEleAt(VectorXZ)} */
+	public final double preferredHeight;
+
+	private boolean isAttached = false;
+	private AttachmentSurface attachedSurface = null;
+	private VectorXYZ attachedPos = null;
+	private VectorXYZ attachedSurfaceNormal = null;
+
+	// TODO: add layer; necessary to support multiple crossing bridges
+
+	/**
+	 *
+	 * @param compatibleSurfaceTypes  list of surface types this can attach to; see {@link AttachmentSurface#getTypes()}
+	 * @param originalPos
+	 * @param changeXZ  whether the horizontal position may be changed
+	 */
+	public AttachmentConnector(List<String> compatibleSurfaceTypes, VectorXYZ originalPos, WorldObject object,
+			double preferredHeight, boolean changeXZ) {
+		this.compatibleSurfaceTypes = compatibleSurfaceTypes;
+		this.originalPos = originalPos;
+		this.object = object;
+		this.maxDistanceXZ = changeXZ ? DEFAULT_MAX_DISTANCE_XZ : 0;
+		this.preferredHeight = preferredHeight;
+	}
+
+	/**
+	 * attach the connector to a surface. Must only be called once.
+	 */
+	public void attach(AttachmentSurface surface, VectorXYZ attachedPos, VectorXYZ attachedSurfaceNormal) {
+
+		if (isAttached) {
+			throw new IllegalStateException("this connector has already been attached");
+		}
+
+		this.isAttached = true;
+		this.attachedSurface = surface;
+		this.attachedPos = attachedPos;
+		this.attachedSurfaceNormal = attachedSurfaceNormal;
+
+		if (attachedPos.xz().distanceTo(originalPos.xz()) > maxDistanceXZ + 0.001) {
+			throw new IllegalArgumentException("this connector must not be moved horizontally");
+		}
+
+	}
+
+	public boolean isAttached() {
+		return isAttached;
+	}
+
+	public AttachmentSurface getAttachedSurface() {
+		if (!isAttached) throw new IllegalStateException("this connector is not attached to a surface");
+		return attachedSurface;
+	}
+
+	public VectorXYZ getAttachedPos() {
+		if (!isAttached) throw new IllegalStateException("this connector is not attached to a surface");
+		return attachedPos;
+	}
+
+	public VectorXYZ getAttachedSurfaceNormal() {
+		if (!isAttached) throw new IllegalStateException("this connector is not attached to a surface");
+		return attachedSurfaceNormal;
+	}
+
+}

--- a/src/main/java/org/osm2world/core/world/attachment/AttachmentSurface.java
+++ b/src/main/java/org/osm2world/core/world/attachment/AttachmentSurface.java
@@ -1,0 +1,125 @@
+package org.osm2world.core.world.attachment;
+
+import static java.util.Arrays.asList;
+import static org.osm2world.core.math.AxisAlignedRectangleXZ.bboxUnion;
+import static org.osm2world.core.math.GeometryUtil.closeLoop;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import org.osm2world.core.math.AxisAlignedRectangleXZ;
+import org.osm2world.core.math.BoundedObject;
+import org.osm2world.core.math.FaceXYZ;
+import org.osm2world.core.math.VectorXYZ;
+import org.osm2world.core.math.VectorXZ;
+import org.osm2world.core.target.common.FaceTarget;
+import org.osm2world.core.target.common.material.Material;
+
+/**
+ * TODO describe the concept
+ */
+public class AttachmentSurface implements BoundedObject {
+
+	/** the surface categories this surface belongs to, e.g. "pole" or "wall" */
+	private final Collection<String> types;
+
+	/** the faces (flat polygons) that define the surface. All faces are counterclockwise */
+	private final Collection<FaceXYZ> faces;
+
+	/**
+	 * the "bottom" elevation of the surface, e.g. the ground elevation for an outdoor feature,
+	 * the floor elevation for an indoor wall, or the elevation of a bridge for a feature on the bridge.
+	 * This allows objects to attach at a sensible height.
+	 * The value will often just be constant for the entire surface,
+	 * but it can be dependent on horizontal location (e.g. for a wall running up a hill).
+	 */
+	private final Function<VectorXZ, Double> baseEleFunction;
+
+	private final Collection<AttachmentConnector> attachedConnectors = new ArrayList<>();
+
+	public AttachmentSurface(Collection<String> types, Collection<FaceXYZ> faces,
+			Function<VectorXZ, Double> baseEleFunction) {
+		if (types.isEmpty() || faces.isEmpty()) throw new IllegalArgumentException();
+		this.types = types;
+		this.faces = faces;
+		this.baseEleFunction = baseEleFunction;
+	}
+
+	public AttachmentSurface(Collection<String> types, Collection<FaceXYZ> faces) {
+		this(types, faces, pos ->
+				faces.stream().flatMap(f -> f.getVertices().stream()).mapToDouble(v -> v.y).min().orElseGet(() -> 0));
+	}
+
+	public Collection<String> getTypes() {
+		return types;
+	}
+
+	public Collection<FaceXYZ> getFaces() {
+		return faces;
+	}
+
+	public double getBaseEleAt(VectorXZ position) {
+		return baseEleFunction.apply(position);
+	}
+
+	public Collection<AttachmentConnector> getAttachedConnectors() {
+		return attachedConnectors;
+	}
+
+	public void addAttachedConnector(AttachmentConnector connector) {
+		this.attachedConnectors.add(connector);
+	}
+
+	@Override
+	public AxisAlignedRectangleXZ boundingBox() {
+		return bboxUnion(faces);
+	}
+
+	public double distanceTo(VectorXYZ v) {
+		return getFaces().stream().mapToDouble(f -> f.distanceTo(v)).min().getAsDouble();
+	}
+
+	@Override
+	public String toString() {
+		return "{" + types + ", " + faces + "}";
+	}
+
+	public static class Builder extends FaceTarget {
+
+		private final Collection<String> types;
+		private final Collection<FaceXYZ> faces = new ArrayList<>();
+		private Function<VectorXZ, Double> baseEleFunction = null;
+
+		public Builder(String... types) {
+			this.types = asList(types);
+		}
+
+		public void setBaseEleFunction(Function<VectorXZ, Double> baseEleFunction) {
+			this.baseEleFunction = baseEleFunction;
+		}
+
+		public AttachmentSurface build() {
+			if (baseEleFunction == null) {
+				return new AttachmentSurface(types, faces);
+			} else {
+				return new AttachmentSurface(types, faces, baseEleFunction);
+			}
+		}
+
+		@Override
+		public void drawFace(Material material, List<VectorXYZ> vs, List<VectorXYZ> normals,
+				List<List<VectorXZ>> texCoordLists) {
+			vs = closeLoop(vs);
+			faces.add(new FaceXYZ(vs));
+		}
+
+		@Override
+		public boolean reconstructFaces() {
+			return false;
+		}
+
+	}
+
+}

--- a/src/main/java/org/osm2world/core/world/data/WorldObject.java
+++ b/src/main/java/org/osm2world/core/world/data/WorldObject.java
@@ -1,10 +1,16 @@
 package org.osm2world.core.world.data;
 
+import static java.util.Collections.emptyList;
+
+import java.util.Collection;
+
 import org.osm2world.core.map_data.data.MapElement;
 import org.osm2world.core.map_elevation.creation.EleConstraintEnforcer;
 import org.osm2world.core.map_elevation.data.EleConnector;
 import org.osm2world.core.map_elevation.data.GroundState;
 import org.osm2world.core.target.Renderable;
+import org.osm2world.core.world.attachment.AttachmentConnector;
+import org.osm2world.core.world.attachment.AttachmentSurface;
 
 public interface WorldObject extends Renderable {
 
@@ -35,5 +41,20 @@ public interface WorldObject extends Renderable {
 	 * {@link EleConnector}s. Called after {@link #getEleConnectors()}.
 	 */
 	public void defineEleConstraints(EleConstraintEnforcer enforcer);
+
+	/**
+	 * returns this object's surfaces that other objects can attach themselves to
+	 * @See {@link AttachmentSurface}
+	 */
+	public default Collection<AttachmentSurface> getAttachmentSurfaces() {
+		return emptyList();
+	}
+
+	/**
+	 * returns all {@link AttachmentConnector}s used by this WorldObject
+	 */
+	public default Iterable<AttachmentConnector> getAttachmentConnectors() {
+		return emptyList();
+	}
 
 }

--- a/src/main/java/org/osm2world/core/world/modules/BarrierModule.java
+++ b/src/main/java/org/osm2world/core/world/modules/BarrierModule.java
@@ -18,15 +18,18 @@ import static org.osm2world.core.world.modules.common.WorldModuleParseUtil.*;
 import static org.osm2world.core.world.network.NetworkUtil.getConnectedNetworkSegments;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.function.Function;
 
 import org.osm2world.core.map_data.data.MapNode;
 import org.osm2world.core.map_data.data.MapWaySegment;
 import org.osm2world.core.map_data.data.TagSet;
 import org.osm2world.core.map_elevation.data.GroundState;
 import org.osm2world.core.math.AxisAlignedRectangleXZ;
+import org.osm2world.core.math.GeometryUtil;
 import org.osm2world.core.math.SimplePolygonXZ;
 import org.osm2world.core.math.VectorXYZ;
 import org.osm2world.core.math.VectorXZ;
@@ -38,6 +41,7 @@ import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.material.Material;
 import org.osm2world.core.target.common.material.Materials;
+import org.osm2world.core.world.attachment.AttachmentSurface;
 import org.osm2world.core.world.data.NoOutlineNodeWorldObject;
 import org.osm2world.core.world.modules.common.AbstractModule;
 import org.osm2world.core.world.network.AbstractNetworkWaySegmentWorldObject;
@@ -194,6 +198,44 @@ public class BarrierModule extends AbstractModule {
 
 		}
 
+		@Override
+		public Collection<AttachmentSurface> getAttachmentSurfaces() {
+
+			/* define the base ele function */
+
+			Function<VectorXZ, Double> baseEleFunction = (VectorXZ point) -> {
+				PolylineXZ centerlineXZ = new PolylineXZ(getCenterlineXZ());
+				double ratio = centerlineXZ.offsetOf(centerlineXZ.closestPoint(point));
+				return GeometryUtil.interpolateOn(getCenterline(), ratio).y;
+			};
+
+			/* return the sides of the wall as attachment surfaces */
+
+			//TODO avoid copypasted code from renderTo
+
+			List<VectorXYZ> leftBottomOutline = getOutline(false);
+			List<VectorXYZ> leftTopOutline = addYList(leftBottomOutline, height);
+
+			List<VectorXYZ> rightBottomOutline = getOutline(true);
+			List<VectorXYZ> rightTopOutline = addYList(rightBottomOutline, height);
+
+			reverse(leftTopOutline);
+			reverse(leftBottomOutline);
+
+			AttachmentSurface.Builder leftBuilder = new AttachmentSurface.Builder("wall");
+			List<VectorXYZ> leftVs = createTriangleStripBetween(leftTopOutline, leftBottomOutline);
+			leftBuilder.drawTriangleStrip(material, leftVs, texCoordLists(leftVs, material, STRIP_WALL));
+			leftBuilder.setBaseEleFunction(baseEleFunction);
+
+			AttachmentSurface.Builder rightBuilder = new AttachmentSurface.Builder("wall");
+			List<VectorXYZ> rightVs = createTriangleStripBetween(rightTopOutline, rightBottomOutline);
+			rightBuilder.drawTriangleStrip(material, rightVs, texCoordLists(rightVs, material, STRIP_WALL));
+			rightBuilder.setBaseEleFunction(baseEleFunction);
+
+			return asList(leftBuilder.build(), rightBuilder.build());
+
+		}
+
 	}
 
 	private static class Wall extends ColoredWall {
@@ -253,6 +295,10 @@ public class BarrierModule extends AbstractModule {
 		}
 		public Hedge(MapWaySegment segment) {
 			super(Materials.HEDGE, segment, 1f, 0.5f);
+		}
+		@Override
+		public Collection<AttachmentSurface> getAttachmentSurfaces() {
+			return emptyList();
 		}
 	}
 

--- a/src/main/java/org/osm2world/core/world/modules/RoadModule.java
+++ b/src/main/java/org/osm2world/core/world/modules/RoadModule.java
@@ -1032,7 +1032,9 @@ public class RoadModule extends ConfigurableWorldModule {
 						}
 
 						for (int i = 0; i < values.length; i++) {
-							resultLists[i].add(new Tag(baseKey, values[i].trim()));
+							if (!resultLists[i].stream().anyMatch(t -> t.key.equals(baseKey))) {
+								resultLists[i].add(new Tag(baseKey, values[i].trim()));
+							}
 						}
 
 					}
@@ -1843,7 +1845,13 @@ public class RoadModule extends ConfigurableWorldModule {
 
 
 				if (!roadTags.contains("highway", "motorway")) {
-					surface = addTurnArrows(surface, laneTags);
+
+					// add turn arrows only if the lane section is long enough (rough rule of thumb)
+					double length = leftLaneBorder.get(0).distanceToXZ(leftLaneBorder.get(leftLaneBorder.size() - 1));
+					if (length > 4.0) {
+						surface = addTurnArrows(surface, laneTags);
+					}
+
 				}
 
 				target.drawTriangleStrip(surface, vs,

--- a/src/main/java/org/osm2world/core/world/modules/StreetFurnitureModule.java
+++ b/src/main/java/org/osm2world/core/world/modules/StreetFurnitureModule.java
@@ -8,7 +8,11 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 import static org.osm2world.core.math.GeometryUtil.equallyDistributePointsAlong;
+import static org.osm2world.core.math.SimplePolygonXZ.asSimplePolygon;
 import static org.osm2world.core.math.VectorXYZ.*;
+import static org.osm2world.core.math.VectorXZ.NULL_VECTOR;
+import static org.osm2world.core.math.algorithms.TriangulationUtil.triangulate;
+import static org.osm2world.core.target.common.ExtrudeOption.*;
 import static org.osm2world.core.target.common.material.Materials.*;
 import static org.osm2world.core.target.common.material.NamedTexCoordFunction.*;
 import static org.osm2world.core.target.common.material.TexCoordUtil.texCoordLists;
@@ -19,6 +23,8 @@ import static org.osm2world.core.world.modules.common.WorldModuleParseUtil.*;
 import java.awt.Color;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,8 +34,11 @@ import org.osm2world.core.map_data.data.MapNode;
 import org.osm2world.core.map_data.data.MapWaySegment;
 import org.osm2world.core.map_elevation.data.GroundState;
 import org.osm2world.core.math.LineSegmentXZ;
+import org.osm2world.core.math.PolygonWithHolesXZ;
+import org.osm2world.core.math.SimplePolygonXZ;
 import org.osm2world.core.math.VectorXYZ;
 import org.osm2world.core.math.VectorXZ;
+import org.osm2world.core.math.shapes.CircleXZ;
 import org.osm2world.core.math.shapes.ShapeXZ;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.TextureData;
@@ -39,6 +48,9 @@ import org.osm2world.core.target.common.material.Material;
 import org.osm2world.core.target.common.material.Material.Interpolation;
 import org.osm2world.core.target.common.material.Materials;
 import org.osm2world.core.target.common.material.TexCoordFunction;
+import org.osm2world.core.world.attachment.AttachmentConnector;
+import org.osm2world.core.world.attachment.AttachmentSurface;
+import org.osm2world.core.world.attachment.AttachmentSurface.Builder;
 import org.osm2world.core.world.data.NoOutlineNodeWorldObject;
 import org.osm2world.core.world.modules.common.AbstractModule;
 
@@ -71,7 +83,9 @@ public class StreetFurnitureModule extends AbstractModule {
 		if (node.getTags().contains("highway", "bus_stop")
 				|| node.getTags().contains("public_transport", "platform")
 				&& node.getTags().contains("bus", "yes")) {
-			node.addRepresentation(new BusStop(node));
+			if (!isInHighway(node)) {
+				node.addRepresentation(new BusStop(node));
+			}
 		}
 		if (node.getTags().contains("man_made", "cross")
 				|| node.getTags().contains("summit:cross", "yes")
@@ -474,8 +488,30 @@ public class StreetFurnitureModule extends AbstractModule {
 
 	private static final class Billboard extends NoOutlineNodeWorldObject {
 
+		private final double width;
+		/** the height of the billboard itself, i.e. height minus minHeight */
+		private final double trueHeight;
+		private final double minHeight;
+
+		private final AttachmentConnector connector;
+
 		public Billboard(MapNode node) {
+
 			super(node);
+
+			width = parseWidth(node.getTags(), 4);
+
+			double height = parseHeight(node.getTags(), 3.5f);
+			minHeight = height / 5;
+			trueHeight = height - minHeight;
+
+			if (node.getTags().contains("support", "wall")) {
+				connector = new AttachmentConnector(asList("wall"),
+						node.getPos().xyz(0), this, minHeight + trueHeight / 2, true);
+			} else {
+				connector = null;
+			}
+
 		}
 
 		@Override
@@ -484,25 +520,37 @@ public class StreetFurnitureModule extends AbstractModule {
 		}
 
 		@Override
+		public Iterable<AttachmentConnector> getAttachmentConnectors() {
+			if (connector == null) {
+				return emptyList();
+			} else {
+				return singleton(connector);
+			}
+		}
+
+		@Override
 		public void renderTo(Target target) {
 
-			float width = parseWidth(node.getTags(), 4);
-			float height = parseHeight(node.getTags(), 3.5f);
-			float minHeight = height / 5;
+			VectorXZ faceVector;
+			VectorXYZ bottomCenter;
 
-			double directionAngle = parseDirection(node.getTags(), PI);
+			if (connector == null || !connector.isAttached()) {
+				faceVector = VectorXZ.fromAngle(parseDirection(node.getTags(), PI));
+				bottomCenter = getBase().addY(minHeight);
+			} else {
+				faceVector = connector.getAttachedSurfaceNormal().xz();
+				bottomCenter = connector.getAttachedPos().addY(-trueHeight/2).add(faceVector.mult(0.01));
+			}
 
-			VectorXZ faceVector = VectorXZ.fromAngle(directionAngle);
 			VectorXZ boardVector = faceVector.rightNormal();
-
 
 			/* draw board */
 
 			VectorXYZ[] vsPoster = {
-					getBase().add(boardVector.mult(width / 2)).addY(height),
-					getBase().add(boardVector.mult(width / 2)).addY(minHeight),
-					getBase().add(boardVector.mult(-width / 2)).addY(height),
-					getBase().add(boardVector.mult(-width / 2)).addY(minHeight)
+					bottomCenter.add(boardVector.mult(width / 2)).addY(trueHeight),
+					bottomCenter.add(boardVector.mult(width / 2)),
+					bottomCenter.add(boardVector.mult(-width / 2)).addY(trueHeight),
+					bottomCenter.add(boardVector.mult(-width / 2))
 			};
 
 			List<VectorXYZ> vsListPoster = asList(vsPoster);
@@ -533,28 +581,32 @@ public class StreetFurnitureModule extends AbstractModule {
 
 			/* draw frame */
 
-			target.drawBox(CONCRETE, getBase().addY(height - 0.1),
+			target.drawBox(CONCRETE, bottomCenter.addY(trueHeight - 0.1),
 					faceVector, 0.1, width, 0.1);
 
-			target.drawBox(CONCRETE, getBase().addY(minHeight),
+			target.drawBox(CONCRETE, bottomCenter,
 					faceVector, 0.1, width, 0.1);
 
-			target.drawBox(CONCRETE, getBase().addY(minHeight).add(boardVector.mult(width / 2)),
-					faceVector, height - minHeight, 0.1, 0.1);
+			target.drawBox(CONCRETE, bottomCenter.add(boardVector.mult(width / 2)),
+					faceVector, trueHeight, 0.1, 0.1);
 
-			target.drawBox(CONCRETE, getBase().addY(minHeight).add(boardVector.mult(-width / 2)),
-					faceVector, height - minHeight, 0.1, 0.1);
+			target.drawBox(CONCRETE, bottomCenter.add(boardVector.mult(-width / 2)),
+					faceVector, trueHeight, 0.1, 0.1);
 
 			/* draw poles */
 
-			VectorXZ[] poles = {
-					node.getPos().add(boardVector.mult(-width / 4)),
-					node.getPos().add(boardVector.mult(+width / 4))
-			};
+			if (connector == null) {
 
-			for (VectorXZ pole : poles) {
-				target.drawBox(CONCRETE, pole.xyz(getBase().y),
-						faceVector, minHeight, 0.2, 0.1);
+				VectorXZ[] poles = {
+						node.getPos().add(boardVector.mult(-width / 4)),
+						node.getPos().add(boardVector.mult(+width / 4))
+				};
+
+				for (VectorXZ pole : poles) {
+					target.drawBox(CONCRETE, pole.xyz(getBase().y),
+							faceVector, minHeight, 0.2, 0.1);
+				}
+
 			}
 
 		}
@@ -1029,13 +1081,34 @@ public class StreetFurnitureModule extends AbstractModule {
 
 	private static final class WasteBasket extends NoOutlineNodeWorldObject {
 
+		private final AttachmentConnector connector;
+
 		public WasteBasket(MapNode node) {
+
 			super(node);
+
+			if (node.getTags().containsKey("support") &&
+					!node.getTags().contains("support", "ground")) {
+				connector = new AttachmentConnector(singletonList(node.getTags().getValue("support")),
+						node.getPos().xyz(0), this, 0.6, true);
+			} else {
+				connector = null;
+			}
+
 		}
 
 		@Override
 		public GroundState getGroundState() {
 			return GroundState.ON;
+		}
+
+		@Override
+		public Iterable<AttachmentConnector> getAttachmentConnectors() {
+			if (connector == null) {
+				return emptyList();
+			} else {
+				return singleton(connector);
+			}
 		}
 
 		@Override
@@ -1045,26 +1118,64 @@ public class StreetFurnitureModule extends AbstractModule {
 
 			Material material = null;
 
-			//TODO parse color
-
-			if (material == null) {
-				material = Materials.getSurfaceMaterial(
-						node.getTags().getValue("material"));
+			if (node.getTags().containsKey("material")) {
+				material = Materials.getMaterial(node.getTags().getValue("material").toUpperCase());
 			}
 
 			if (material == null) {
-				material = Materials.getSurfaceMaterial(
-						node.getTags().getValue("surface"), STEEL);
+				material = STEEL;
 			}
 
-			/* draw pole */
-			target.drawColumn(material, null, getBase(),
-					1.2, 0.06, 0.06, false, true);
+			material = material.withColor(parseColor(node.getTags().getValue("colour"), CSS_COLORS));
+
+			/* determine position */
+
+			VectorXYZ pos;
+			VectorXYZ direction = X_UNIT;
+
+			if (connector != null && connector.isAttached()) {
+
+				pos = connector.getAttachedPos();
+				direction = connector.getAttachedSurfaceNormal();
+
+			} else {
+
+				pos = getBase().addY(0.6).add(direction.mult(0.05));
+
+				/* draw pole */
+				target.drawColumn(material, null, getBase(), 1.2, 0.06, 0.06, false, true);
+
+			}
 
 			/* draw basket */
-			target.drawColumn(material, null,
-					getBase().addY(0.5).add(0.25, 0f, 0f),
-					0.5, 0.2, 0.2, true, true);
+			renderBasket(target, material, pos, direction);
+
+		}
+
+		private void renderBasket(Target target, Material material, VectorXYZ pos, VectorXYZ direction) {
+
+			double height = 0.5;
+			double radius = 0.2;
+
+			VectorXYZ bottomCenter = pos.addY(-0.1).add(direction.mult(0.2));
+			VectorXYZ innerBottomCenter = bottomCenter.addY(height * 0.05);
+			VectorXYZ topCenter = bottomCenter.addY(height);
+
+			CircleXZ outerRing = new CircleXZ(NULL_VECTOR, radius);
+
+			SimplePolygonXZ innerRing = asSimplePolygon(new CircleXZ(NULL_VECTOR, radius * 0.95));
+			innerRing = innerRing.reverse();
+
+			PolygonWithHolesXZ upperDonut = new PolygonWithHolesXZ(asSimplePolygon(outerRing), singletonList(innerRing));
+
+			target.drawExtrudedShape(material, outerRing, asList(bottomCenter, topCenter),
+					nCopies(2, Z_UNIT), null, null, EnumSet.of(START_CAP));
+
+			target.drawExtrudedShape(material, innerRing, asList(topCenter, innerBottomCenter),
+					nCopies(2, Z_UNIT), null, null, EnumSet.of(END_CAP));
+
+			triangulate(upperDonut).forEach(it -> target.drawShape(material, it, topCenter, Y_UNIT, Z_UNIT, 1));
+
 		}
 
 	}
@@ -1367,31 +1478,39 @@ public class StreetFurnitureModule extends AbstractModule {
 
 		@Override
 		public void renderTo(Target target) {
-			if (!isInHighway(node)) {
-				float height = parseHeight(node.getTags(), 3f);
-				float signHeight = 0.7f;
-				float signWidth = 0.4f;
 
-				Material poleMaterial = STEEL;
+			float height = parseHeight(node.getTags(), 3f);
+			float signHeight = 0.7f;
+			float signWidth = 0.4f;
 
-				double directionAngle = parseDirection(node.getTags(), PI);
+			Material poleMaterial = STEEL;
 
-				VectorXZ faceVector = VectorXZ.fromAngle(directionAngle);
+			double directionAngle = parseDirection(node.getTags(), PI);
 
-				target.drawColumn(poleMaterial, null,
-						getBase(),
-						height - signHeight, 0.05, 0.05, true, true);
-				/* draw sign */
-				target.drawBox(BUS_STOP_SIGN,
-						getBase().addY(height - signHeight),
-						faceVector, signHeight, signWidth, 0.02);
-				/*  draw timetable */
-				target.drawBox(poleMaterial,
-						getBase().addY(1.2f).add(new VectorXYZ(0.055f, 0, 0f).rotateY(directionAngle)),
-						faceVector, 0.31, 0.01, 0.43);
+			VectorXZ faceVector = VectorXZ.fromAngle(directionAngle);
 
-				//TODO Add Shelter and bench
-			}
+			target.drawColumn(poleMaterial, null,
+					getBase(),
+					height - signHeight, 0.05, 0.05, false, true);
+
+			if (target instanceof AttachmentSurface.Builder) return;
+
+			/* draw sign */
+			target.drawBox(BUS_STOP_SIGN,
+					getBase().addY(height - signHeight),
+					faceVector, signHeight, signWidth, 0.02);
+			/*  draw timetable */
+			target.drawBox(poleMaterial,
+					getBase().addY(1.2f).add(new VectorXYZ(0.055f, 0, 0f).rotateY(directionAngle)),
+					faceVector, 0.31, 0.01, 0.43);
+
+		}
+
+		@Override
+		public Collection<AttachmentSurface> getAttachmentSurfaces() {
+			Builder builder = new AttachmentSurface.Builder("bus_stop", "pole");
+			this.renderTo(builder);
+			return singleton(builder.build());
 		}
 
 	}
@@ -1551,6 +1670,8 @@ public class StreetFurnitureModule extends AbstractModule {
 					getBase().addY(0.5),
 					poleHeight, 0.08, 0.08, false, false);
 
+			if (target instanceof AttachmentSurface.Builder) return;
+
 			/* draw lamp */
 
 			// lower part
@@ -1574,6 +1695,13 @@ public class StreetFurnitureModule extends AbstractModule {
 			vs.add(getBase().addY(poleHeight + lampHeight * 0.8).add(lampHalfWidth, 0, lampHalfWidth));
 
 			target.drawTriangleFan(material, vs, null);
+		}
+
+		@Override
+		public Collection<AttachmentSurface> getAttachmentSurfaces() {
+			Builder builder = new AttachmentSurface.Builder("street_lamp", "pole");
+			this.renderTo(builder);
+			return singleton(builder.build());
 		}
 
 	}

--- a/src/main/java/org/osm2world/core/world/modules/building/Building.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/Building.java
@@ -5,11 +5,17 @@ import static org.osm2world.core.map_elevation.data.GroundState.ON;
 import static org.osm2world.core.math.GeometryUtil.roughlyContains;
 
 import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.configuration.Configuration;
 import org.osm2world.core.map_data.data.MapArea;
 import org.osm2world.core.map_data.data.MapElement;
 import org.osm2world.core.map_data.data.MapNode;
+import org.osm2world.core.map_data.data.MapRelation;
+import org.osm2world.core.map_data.data.MapRelation.Membership;
 import org.osm2world.core.map_data.data.overlaps.MapOverlap;
 import org.osm2world.core.map_elevation.creation.EleConstraintEnforcer;
 import org.osm2world.core.map_elevation.data.EleConnector;
@@ -43,18 +49,40 @@ public class Building implements AreaWorldObject, TerrainBoundaryWorldObject {
 
 		this.area = area;
 
-		for (MapOverlap<?,?> overlap : area.getOverlaps()) {
-			MapElement other = overlap.getOther(area);
-			if (other instanceof MapArea
-					&& other.getTags().containsKey("building:part")) {
+		Optional<MapRelation> buildingRelation = area.getMemberships().stream()
+				.filter(it -> "outline".equals(it.getRole()))
+				.map(Membership::getRelation)
+				.filter(it -> it.getTags().contains("type", "building"))
+				.findAny();
 
-				MapArea otherArea = (MapArea)other;
+		if (buildingRelation.isPresent()) {
 
-				if (roughlyContains(area.getPolygon(), otherArea.getPolygon().getOuter())) {
-					parts.add(new BuildingPart(this, otherArea, config));
+			/** find building parts based on the relation */
+
+			for (Membership membership : buildingRelation.get().getMemberships()) {
+				if ("part".equals(membership.getRole()) && membership.getElement() instanceof MapArea) {
+					parts.add(new BuildingPart(this, (MapArea) membership.getElement(), config));
 				}
-
 			}
+
+		} else {
+
+			/** find building part areas geometrically contained within the building outline */
+
+			for (MapOverlap<?,?> overlap : area.getOverlaps()) {
+				MapElement other = overlap.getOther(area);
+				if (other instanceof MapArea
+						&& other.getTags().containsKey("building:part")) {
+
+					MapArea otherArea = (MapArea)other;
+
+					if (roughlyContains(area.getPolygon(), otherArea.getPolygon().getOuter())) {
+						parts.add(new BuildingPart(this, otherArea, config));
+					}
+
+				}
+			}
+
 		}
 
 		/* use the building itself as a part if no parts exist,

--- a/src/main/java/org/osm2world/core/world/modules/building/Building.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/Building.java
@@ -4,13 +4,12 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.osm2world.core.map_elevation.data.GroundState.ON;
 import static org.osm2world.core.math.GeometryUtil.roughlyContains;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import org.apache.commons.configuration.Configuration;
 import org.osm2world.core.map_data.data.MapArea;
 import org.osm2world.core.map_data.data.MapElement;
+import org.osm2world.core.map_data.data.MapNode;
 import org.osm2world.core.map_data.data.overlaps.MapOverlap;
 import org.osm2world.core.map_elevation.creation.EleConstraintEnforcer;
 import org.osm2world.core.map_elevation.data.EleConnector;
@@ -34,6 +33,8 @@ public class Building implements AreaWorldObject, TerrainBoundaryWorldObject {
 	private final List<BuildingPart> parts = new ArrayList<>();
 
 	private final EleConnectorGroup outlineConnectors;
+
+	private Map<NodeLevelPair, Boolean> windowNodes = new HashMap<>();
 
 	public Building(MapArea area, Configuration config) {
 
@@ -143,6 +144,51 @@ public class Building implements AreaWorldObject, TerrainBoundaryWorldObject {
 		}
 
 		return shapes;
+	}
+
+	private class NodeLevelPair{
+
+		private final MapNode node;
+		private final Integer level;
+
+		NodeLevelPair(MapNode node, Integer level) {
+			this.node = node;
+			this.level = level;
+		}
+
+		@Override
+		public boolean equals(Object anObject){
+			if (anObject instanceof NodeLevelPair) {
+				NodeLevelPair temp = (NodeLevelPair) anObject;
+				if (temp.level.equals(this.level) && temp.node.equals(this.node)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		@Override
+		public int hashCode() {
+			return  Long.hashCode(node.getId()) / ((level * 2) + 1);
+		}
+
+	}
+
+	public void addWindowNode(MapNode node, Integer level){
+		if (windowNodes.get(new NodeLevelPair(node, level)) != null) {
+			windowNodes.replace(new NodeLevelPair(node, level), true);
+		} else {
+			windowNodes.put(new NodeLevelPair(node, level), false);
+		}
+	}
+
+	public void addListWindowNodes(List<MapNode> nodes, Integer level) {
+		nodes.forEach(n -> addWindowNode(n, level));
+	}
+
+	public Boolean queryWindowSegments(MapNode node, Integer level){
+		return Boolean.TRUE.equals(windowNodes.get(new NodeLevelPair(node, level)));
 	}
 
 }

--- a/src/main/java/org/osm2world/core/world/modules/building/Building.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/Building.java
@@ -1,15 +1,5 @@
 package org.osm2world.core.world.modules.building;
 
-import static java.lang.Double.POSITIVE_INFINITY;
-import static org.osm2world.core.map_elevation.data.GroundState.ON;
-import static org.osm2world.core.math.GeometryUtil.roughlyContains;
-
-import java.util.*;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.commons.configuration.Configuration;
 import org.osm2world.core.map_data.data.MapArea;
 import org.osm2world.core.map_data.data.MapElement;
@@ -30,6 +20,12 @@ import org.osm2world.core.target.Target;
 import org.osm2world.core.world.data.AreaWorldObject;
 import org.osm2world.core.world.data.TerrainBoundaryWorldObject;
 import org.osm2world.core.world.modules.building.indoor.IndoorWall;
+
+import java.util.*;
+
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.osm2world.core.map_elevation.data.GroundState.ON;
+import static org.osm2world.core.math.GeometryUtil.roughlyContains;
 
 /**
  * a building. Rendering a building is implemented as rendering all of its {@link BuildingPart}s.

--- a/src/main/java/org/osm2world/core/world/modules/building/BuildingPart.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/BuildingPart.java
@@ -595,6 +595,8 @@ public class BuildingPart implements Renderable {
 
 	public Indoor getIndoor(){ return indoor; }
 
+	public double getHeightWithoutRoof() { return heightWithoutRoof; }
+
 	@Override
 	public void renderTo(Target target) {
 

--- a/src/main/java/org/osm2world/core/world/modules/building/BuildingPart.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/BuildingPart.java
@@ -591,7 +591,7 @@ public class BuildingPart implements Renderable {
 
 	int getBuildingLevels() { return buildingLevels; }
 
-	int getMinLevel() { return buildingMinLevel; }
+	public int getMinLevel() { return buildingMinLevel; }
 
 	public Indoor getIndoor(){ return indoor; }
 

--- a/src/main/java/org/osm2world/core/world/modules/building/BuildingPart.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/BuildingPart.java
@@ -344,6 +344,10 @@ public class BuildingPart implements Renderable {
 			}
 		}
 
+		for (int i = getMinLevel(); i < getBuildingLevels() + 1; i++) {
+			getBuilding().addListWindowNodes(area.getBoundaryNodes(), i);
+		}
+
 	}
 
 	/** creates the walls, floors etc. making up this part */

--- a/src/main/java/org/osm2world/core/world/modules/building/Door.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/Door.java
@@ -17,7 +17,7 @@ import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.TextureData;
 import org.osm2world.core.target.common.material.Material;
 
-class Door implements WallElement {
+public class Door implements WallElement {
 
 	/** position on a wall surface */
 	private final VectorXZ position;

--- a/src/main/java/org/osm2world/core/world/modules/building/DoorParameters.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/DoorParameters.java
@@ -16,7 +16,7 @@ import org.osm2world.core.map_data.data.TagSet;
  * data about a door.
  * This object type is immutable after its construction from a set of tags.
  */
-class DoorParameters {
+public class DoorParameters {
 
 	public final String type;
 	public final @Nullable String materialName;

--- a/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
@@ -1,5 +1,16 @@
 package org.osm2world.core.world.modules.building;
 
+import org.osm2world.core.math.*;
+import org.osm2world.core.math.algorithms.JTSBufferUtil;
+import org.osm2world.core.math.shapes.CircleXZ;
+import org.osm2world.core.math.shapes.ShapeXZ;
+import org.osm2world.core.math.shapes.SimplePolygonShapeXZ;
+import org.osm2world.core.target.Target;
+import org.osm2world.core.target.common.ExtrudeOption;
+import org.osm2world.core.target.common.material.Material;
+
+import java.util.*;
+
 import static java.lang.Math.max;
 import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
@@ -8,31 +19,9 @@ import static org.osm2world.core.math.GeometryUtil.interpolateBetween;
 import static org.osm2world.core.math.SimplePolygonXZ.asSimplePolygon;
 import static org.osm2world.core.math.algorithms.TriangulationUtil.triangulate;
 import static org.osm2world.core.target.common.material.NamedTexCoordFunction.STRIP_WALL;
-import static org.osm2world.core.target.common.material.TexCoordUtil.*;
+import static org.osm2world.core.target.common.material.TexCoordUtil.texCoordLists;
+import static org.osm2world.core.target.common.material.TexCoordUtil.triangleTexCoordLists;
 import static org.osm2world.core.world.modules.common.WorldModuleGeometryUtil.createTriangleStripBetween;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.List;
-
-import org.osm2world.core.math.AxisAlignedRectangleXZ;
-import org.osm2world.core.math.LineSegmentXZ;
-import org.osm2world.core.math.PolygonXYZ;
-import org.osm2world.core.math.SimplePolygonXZ;
-import org.osm2world.core.math.TriangleXYZ;
-import org.osm2world.core.math.TriangleXZ;
-import org.osm2world.core.math.VectorXYZ;
-import org.osm2world.core.math.VectorXZ;
-import org.osm2world.core.math.algorithms.JTSBufferUtil;
-import org.osm2world.core.math.shapes.CircleXZ;
-import org.osm2world.core.math.shapes.ShapeXZ;
-import org.osm2world.core.math.shapes.SimplePolygonShapeXZ;
-import org.osm2world.core.target.Target;
-import org.osm2world.core.target.common.ExtrudeOption;
-import org.osm2world.core.target.common.material.Material;
 
 public class GeometryWindow implements Window {
 

--- a/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
@@ -58,12 +58,12 @@ public class GeometryWindow implements Window {
 		this.transparent = transparent;
 
 		switch (params.windowShape) {
-		case CIRCLE:
+		case ROUND:
 			outline = circleShape(position, params.width, params.height);
 			paneOutline = circleShape(position.add(new VectorXZ(0, OUTER_FRAME_WIDTH / 2)),
 					params.width - OUTER_FRAME_WIDTH, params.height - OUTER_FRAME_WIDTH);
 			break;
-		case RECTANGLE:
+		case RECTANGULAR:
 		default:
 			outline = rectangleShape(position, params.width, params.height);
 			paneOutline = rectangleShape(position.add(new VectorXZ(0, OUTER_FRAME_WIDTH / 2)),
@@ -158,7 +158,7 @@ public class GeometryWindow implements Window {
 				triangleTexCoordLists(frontFaceTrianglesXYZ, params.frameMaterial, surface::texCoordsGlobal));
 
 		Material frameSideMaterial = params.frameMaterial;
-		if (params.windowShape == WindowParameters.WindowShape.CIRCLE) {
+		if (params.windowShape == WindowParameters.WindowShape.ROUND) {
 			frameSideMaterial = frameSideMaterial.makeSmooth();
 		}
 

--- a/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
@@ -49,10 +49,13 @@ public class GeometryWindow implements Window {
 	private final SimplePolygonXZ paneOutline;
 	private final List<List<VectorXZ>> innerFramePaths;
 
-	public GeometryWindow(VectorXZ position, WindowParameters params) {
+	private final boolean transparent;
+
+	public GeometryWindow(VectorXZ position, WindowParameters params, boolean transparent) {
 
 		this.position = position;
 		this.params = params;
+		this.transparent = transparent;
 
 		switch (params.windowShape) {
 		case CIRCLE:
@@ -126,12 +129,20 @@ public class GeometryWindow implements Window {
 
 		/* draw the window pane */
 
+		String paneType;
+
+		if (transparent) {
+			paneType = "TRANSPARENT";
+		} else {
+			paneType = "OPAQUE";
+		}
+
 		Collection<TriangleXZ> paneTrianglesXZ = paneOutline.getTriangulation();
 		Collection<TriangleXYZ> paneTriangles = paneTrianglesXZ.stream()
 				.map(t -> surface.convertTo3D(t).shift(toBack))
 				.collect(toList());
-		target.drawTriangles(params.windowMaterial, paneTriangles,
-				triangleTexCoordLists(paneTriangles, params.windowMaterial, surface::texCoordsGlobal));
+		target.drawTriangles(params.windowMaterial.get(paneType), paneTriangles,
+				triangleTexCoordLists(paneTriangles, params.windowMaterial.get(paneType), surface::texCoordsGlobal));
 
 		/* draw outer frame */
 

--- a/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/GeometryWindow.java
@@ -34,7 +34,7 @@ import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.ExtrudeOption;
 import org.osm2world.core.target.common.material.Material;
 
-class GeometryWindow implements Window {
+public class GeometryWindow implements Window {
 
 	private static final double DEPTH = 0.10;
 	private static final double OUTER_FRAME_WIDTH = 0.1;

--- a/src/main/java/org/osm2world/core/world/modules/building/Wall.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/Wall.java
@@ -256,9 +256,11 @@ public class Wall implements Renderable {
 				} else if (node.getTags().containsKey("window")
 						&& !node.getTags().contains("window", "no")) {
 
+					boolean transparent = buildingPart.getBuilding().queryWindowSegments(node, level);
+
 					TagSet windowTags = inheritTags(node.getTags(), tags);
 					WindowParameters params = new WindowParameters(windowTags, buildingPart.getLevelHeight(level));
-					GeometryWindow window = new GeometryWindow(new VectorXZ(pos.x, pos.z + params.breast), params);
+					GeometryWindow window = new GeometryWindow(new VectorXZ(pos.x, pos.z + params.breast), params, transparent);
 					mainSurface.addElementIfSpaceFree(window);
 
 					individuallyMappedWindows = true;
@@ -350,7 +352,7 @@ public class Wall implements Renderable {
 						heightAboveBase + windowParams.breast);
 
 				Window window = implementation == WindowImplementation.FULL_GEOMETRY
-						? new GeometryWindow(pos, windowParams)
+						? new GeometryWindow(pos, windowParams, false)
 						: new TexturedWindow(pos, windowParams);
 				surface.addElementIfSpaceFree(window);
 

--- a/src/main/java/org/osm2world/core/world/modules/building/WindowParameters.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/WindowParameters.java
@@ -12,7 +12,7 @@ import org.osm2world.core.target.common.material.Materials;
  * data about the window(s) on a wall, door, or for a single window.
  * This object type is immutable after its construction from a set of tags.
  */
-class WindowParameters {
+public class WindowParameters {
 
 	private static enum WindowType {
 		PLAIN, DISPLAY_WINDOW

--- a/src/main/java/org/osm2world/core/world/modules/building/WindowParameters.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/WindowParameters.java
@@ -23,10 +23,10 @@ public class WindowParameters {
 
 	static enum WindowShape {
 
-		RECTANGLE, CIRCLE, ROUNDTOP;
+		RECTANGULAR, ROUND;
 
 		/**
-		 * convenient alternative to valueOf
+		 * convenient case-insensitive and exception-free alternative to valueOf
 		 * @return  the matching value, can be null
 		 */
 		public static WindowParameters.WindowShape getValue(String shapeName) {
@@ -110,7 +110,7 @@ public class WindowParameters {
 		}
 
 		WindowParameters.WindowShape tempWindowShape = WindowShape.getValue(tags.getValue("window:shape"));
-		windowShape = tempWindowShape != null ? tempWindowShape : WindowShape.RECTANGLE;
+		windowShape = tempWindowShape != null ? tempWindowShape : WindowShape.RECTANGULAR;
 
 		/* frame */
 

--- a/src/main/java/org/osm2world/core/world/modules/building/WindowParameters.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/WindowParameters.java
@@ -8,6 +8,9 @@ import org.osm2world.core.map_data.data.TagSet;
 import org.osm2world.core.target.common.material.Material;
 import org.osm2world.core.target.common.material.Materials;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * data about the window(s) on a wall, door, or for a single window.
  * This object type is immutable after its construction from a set of tags.
@@ -63,7 +66,7 @@ public class WindowParameters {
 
 	public final WindowParameters.WindowShape windowShape;
 
-	public final Material windowMaterial;
+	public Map<String, Material> windowMaterial = new HashMap<>();
 	public final Material frameMaterial;
 	public final Material shutterMaterial;
 
@@ -79,10 +82,13 @@ public class WindowParameters {
 			type = WindowType.PLAIN;
 		}
 
-		windowMaterial = BuildingPart.buildMaterial(
+		windowMaterial.put("OPAQUE", BuildingPart.buildMaterial(
 				tags.getValue("window:material"),
 				tags.getValue("window:colour"),
-				Materials.GLASS, false);
+				Materials.GLASS, false));
+
+		windowMaterial.put("TRANSPARENT", BuildingPart.buildMaterial(null, tags.getValue("window:colour"),
+				Materials.GLASS_TRANSPARENT, false));
 
 		numberWindows = parseUInt(tags.getValue("window:count"));
 		groupSize = parseUInt(tags.getValue("window:group_size"), 1);

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/Ceiling.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/Ceiling.java
@@ -1,17 +1,19 @@
 package org.osm2world.core.world.modules.building.indoor;
 
-import org.osm2world.core.math.PolygonWithHolesXZ;
-import org.osm2world.core.math.TriangleXYZ;
-import org.osm2world.core.math.TriangleXZ;
+import org.osm2world.core.math.*;
 import org.osm2world.core.math.algorithms.TriangulationUtil;
+import org.osm2world.core.math.shapes.ShapeXZ;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.material.Material;
 import org.osm2world.core.world.modules.building.BuildingPart;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
+import static org.osm2world.core.math.VectorXYZ.*;
 import static org.osm2world.core.target.common.material.NamedTexCoordFunction.GLOBAL_X_Z;
 import static org.osm2world.core.target.common.material.TexCoordUtil.triangleTexCoordLists;
 
@@ -35,12 +37,23 @@ public class Ceiling {
 
         if (render && polygon != null) {
 
-            double floorEle = buildingPart.getBuildingPartBaseEle() + floorHeight - 0.01;
+            double floorEle = buildingPart.getBuildingPartBaseEle() + floorHeight;
+
+            ShapeXZ shape = polygon.getOuter().makeCounterclockwise();
+
+            VectorXYZ bottom = new VectorXYZ(0,floorEle - 0.2,0);
+            VectorXYZ top = new VectorXYZ(0,floorEle,0);
+
+            List<VectorXYZ> path = new ArrayList<>();
+            path.add(bottom);
+            path.add(top);
+
+            target.drawExtrudedShape(material, shape, path, nCopies(2, Z_UNIT), null, null, null);
 
             Collection<TriangleXZ> triangles = TriangulationUtil.triangulate(polygon);
 
             List<TriangleXYZ> trianglesXYZ = triangles.stream()
-                    .map(t -> t.makeClockwise().xyz(floorEle))
+                    .map(t -> t.makeClockwise().xyz(floorEle - 0.2))
                     .collect(toList());
 
             target.drawTriangles(material, trianglesXYZ,

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/Ceiling.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/Ceiling.java
@@ -1,6 +1,9 @@
 package org.osm2world.core.world.modules.building.indoor;
 
-import org.osm2world.core.math.*;
+import org.osm2world.core.math.PolygonWithHolesXZ;
+import org.osm2world.core.math.TriangleXYZ;
+import org.osm2world.core.math.TriangleXZ;
+import org.osm2world.core.math.VectorXYZ;
 import org.osm2world.core.math.algorithms.TriangulationUtil;
 import org.osm2world.core.math.shapes.ShapeXZ;
 import org.osm2world.core.target.Target;
@@ -13,7 +16,7 @@ import java.util.List;
 
 import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
-import static org.osm2world.core.math.VectorXYZ.*;
+import static org.osm2world.core.math.VectorXYZ.Z_UNIT;
 import static org.osm2world.core.target.common.material.NamedTexCoordFunction.GLOBAL_X_Z;
 import static org.osm2world.core.target.common.material.TexCoordUtil.triangleTexCoordLists;
 

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/Corridor.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/Corridor.java
@@ -1,5 +1,6 @@
 package org.osm2world.core.world.modules.building.indoor;
 
+import org.osm2world.core.map_data.data.MapArea;
 import org.osm2world.core.math.PolygonWithHolesXZ;
 import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
@@ -20,6 +21,10 @@ public class Corridor implements Renderable {
         Material material = data.getMaterial(BuildingDefaults.getDefaultsFor(data.getBuildingPart().getTags()).materialWall);
         PolygonWithHolesXZ polygon = data.getPolygon();
         Double floorHeight = (double) data.getLevelHeightAboveBase();
+
+        if (data.getMapElement() instanceof MapArea) {
+            data.getBuildingPart().getBuilding().addListWindowNodes(((MapArea) data.getMapElement()).getBoundaryNodes(), data.getMinLevel());
+        }
 
         floor = new IndoorFloor(data.getBuildingPart(), data.getSurface(), polygon, floorHeight, data.getRenderableLevels().contains(data.getMinLevel()));
         ceiling = new Ceiling(data.getBuildingPart(), material, polygon, data.getTopOfTopLevelHeightAboveBase(), data.getRenderableLevels().contains(data.getMaxLevel()));

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorArea.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorArea.java
@@ -1,5 +1,6 @@
 package org.osm2world.core.world.modules.building.indoor;
 
+import org.osm2world.core.map_data.data.MapArea;
 import org.osm2world.core.math.PolygonWithHolesXZ;
 import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
@@ -20,6 +21,10 @@ public class IndoorArea implements Renderable {
         Material material = data.getMaterial(BuildingDefaults.getDefaultsFor(data.getBuildingPart().getTags()).materialWall);
         PolygonWithHolesXZ polygon = data.getPolygon();
         Double floorHeight = (double) data.getLevelHeightAboveBase();
+
+        if (data.getMapElement() instanceof MapArea) {
+            data.getBuildingPart().getBuilding().addListWindowNodes(((MapArea) data.getMapElement()).getBoundaryNodes(), data.getMinLevel());
+        }
 
         floor = new IndoorFloor(data.getBuildingPart(), data.getSurface(), polygon, floorHeight, data.getRenderableLevels().contains(data.getMinLevel()));
         ceiling = new Ceiling(data.getBuildingPart(), material, polygon, floorHeight, data.getRenderableLevels().contains(data.getMinLevel()));

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorFloor.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorFloor.java
@@ -35,7 +35,7 @@ public class IndoorFloor {
 
         if (render && polygon != null) {
 
-            double floorEle = buildingPart.getBuildingPartBaseEle() + floorHeight + 0.01;
+            double floorEle = buildingPart.getBuildingPartBaseEle() + floorHeight;
 
             Collection<TriangleXZ> triangles = TriangulationUtil.triangulate(polygon);
 

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorFloor.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorFloor.java
@@ -35,7 +35,7 @@ public class IndoorFloor {
 
         if (render && polygon != null) {
 
-            double floorEle = buildingPart.getBuildingPartBaseEle() + floorHeight;
+            double floorEle = buildingPart.getBuildingPartBaseEle() + floorHeight + 0.0001;
 
             Collection<TriangleXZ> triangles = TriangulationUtil.triangulate(polygon);
 

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorRoom.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorRoom.java
@@ -1,5 +1,6 @@
 package org.osm2world.core.world.modules.building.indoor;
 
+import org.osm2world.core.map_data.data.MapArea;
 import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.world.modules.building.BuildingDefaults;
@@ -32,6 +33,11 @@ public class IndoorRoom implements Renderable {
                 data.getPolygon(),
                 data.getTopOfTopLevelHeightAboveBase(),
                 data.getRenderableLevels().contains(data.getMaxLevel()));
+
+        if (data.getMapElement() instanceof MapArea) {
+            data.getLevels().forEach(l ->  data.getBuildingPart().getBuilding().addListWindowNodes(((MapArea) data.getMapElement()).getBoundaryNodes(), l));
+        }
+
     }
 
     private List<IndoorWall> splitIntoIndoorWalls(){

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorRoom.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorRoom.java
@@ -1,12 +1,8 @@
 package org.osm2world.core.world.modules.building.indoor;
 
-import org.osm2world.core.map_data.data.*;
 import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
-import org.osm2world.core.target.common.material.Material;
-import org.osm2world.core.target.common.material.Materials;
 import org.osm2world.core.world.modules.building.BuildingDefaults;
-import org.osm2world.core.world.modules.building.BuildingPart;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
@@ -91,7 +91,7 @@ public class IndoorWall implements Renderable {
         MapNode prevNode = nodes.get(0);
         List<MapNode> intermediateNodes = new ArrayList<>();
 
-        for (int i = 1; i < nodes.size(); i++) {
+		for (int i = 1; i < nodes.size(); i++) {
 
             MapNode node = nodes.get(i);
 
@@ -611,7 +611,7 @@ public class IndoorWall implements Renderable {
 
                 SegmentLevelPair pair = new SegmentLevelPair(wallSegData.getSegment(), level);
 
-                if (!allRenderedWallSegments.contains(pair)) {
+				if (!allRenderedWallSegments.contains(pair)) {
 
                     allRenderedWallSegments.add(pair);
 
@@ -702,11 +702,13 @@ public class IndoorWall implements Renderable {
 							if (node.getTags().containsKey("window")
                                 && !node.getTags().contains("window", "no")) {
 
+								boolean transparent = data.getBuildingPart().getBuilding().queryWindowSegments(node, level);
+
                                 TagSet windowTags = inheritTags(node.getTags(), data.getTags());
                                 WindowParameters params = new WindowParameters(windowTags, data.getBuildingPart().getLevelHeight(level));
 
-                                GeometryWindow windowFront = new GeometryWindow(new VectorXZ(offset, params.breast), params);
-                                GeometryWindow windowBack = new GeometryWindow(new VectorXZ(wallSegData.segment.getLength() - offset, params.breast), params);
+                                GeometryWindow windowFront = new GeometryWindow(new VectorXZ(offset, params.breast), params, transparent);
+                                GeometryWindow windowBack = new GeometryWindow(new VectorXZ(wallSegData.segment.getLength() - offset, params.breast), params, transparent);
 
                                 mainSurface.addElementIfSpaceFree(windowFront);
                                 backSurface.addElementIfSpaceFree(windowBack);

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
@@ -8,15 +8,14 @@ import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.material.Material;
 import org.osm2world.core.target.common.material.Materials;
-import org.osm2world.core.world.modules.building.*;
 import org.osm2world.core.world.modules.building.Building.NodeLevelPair;
+import org.osm2world.core.world.modules.building.*;
 import org.osm2world.core.world.modules.building.roof.Roof;
 
-import javax.sound.sampled.Line;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static java.lang.Math.*;
+import static java.lang.Math.abs;
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
@@ -70,7 +69,11 @@ public class IndoorWall implements Renderable {
 
     }
 
-    private boolean isCornerOrEnd(int index) {
+	public List<SegmentNodes> getWallSegmentNodes() { return wallSegmentNodes; }
+
+	public double getWallThickness() { return wallThickness; }
+
+	private boolean isCornerOrEnd(int index) {
 
         if (index == 0 || index == nodes.size() - 1) {
             return true;
@@ -110,15 +113,15 @@ public class IndoorWall implements Renderable {
 
     }
 
-    private class SegmentNodes {
+    public class SegmentNodes {
 
         private List<MapNode> nodes;
         private LineSegmentXZ segment;
         private MapNode startNode;
         private MapNode endNode;
 
-        SegmentNodes(List<MapNode> allNodes, LineSegmentXZ segment, MapNode startNode, MapNode endNode){
-            nodes = allNodes;
+        SegmentNodes(List<MapNode> intermediateNodes, LineSegmentXZ segment, MapNode startNode, MapNode endNode){
+            nodes = intermediateNodes;
             this.segment = segment;
             this.startNode = startNode;
             this.endNode = endNode;
@@ -591,7 +594,7 @@ public class IndoorWall implements Renderable {
 	}
 
 
-    private List<VectorXZ> getNewEndPoints(SegmentNodes wallSegData, int level, double heightAboveGround, double ceilingHeightAboveGround){
+    public List<VectorXZ> getNewEndPoints(SegmentNodes wallSegData, int level, double heightAboveGround, double ceilingHeightAboveGround){
 
     	List<VectorXZ> result = new ArrayList<>();
 

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
@@ -1,9 +1,8 @@
 package org.osm2world.core.world.modules.building.indoor;
 
 import org.osm2world.core.map_data.data.*;
-import org.osm2world.core.math.LineSegmentXZ;
-import org.osm2world.core.math.VectorXYZ;
-import org.osm2world.core.math.VectorXZ;
+import org.osm2world.core.math.*;
+import org.osm2world.core.math.algorithms.TriangulationUtil;
 import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.material.Material;
@@ -14,12 +13,21 @@ import org.osm2world.core.world.modules.building.roof.Roof;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.lang.Math.abs;
+import static java.lang.Math.ceil;
 import static java.util.Collections.*;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.math3.util.MathUtils.TWO_PI;
 import static org.osm2world.core.math.VectorXZ.listXYZ;
+import static org.osm2world.core.target.common.material.NamedTexCoordFunction.GLOBAL_X_Z;
+import static org.osm2world.core.target.common.material.TexCoordUtil.triangleTexCoordLists;
 import static org.osm2world.core.util.ValueParseUtil.parseLevels;
 import static org.osm2world.core.world.modules.common.WorldModuleParseUtil.inheritTags;
 
 public class IndoorWall implements Renderable {
+
+	private final double straightnessTolerance = 0.05;
+	private final double wallThickness = 0.1;
 
     private final Float wallHeight;
     private final Float floorHeight;
@@ -70,7 +78,7 @@ public class IndoorWall implements Renderable {
 
         // TODO tolerance may need tweaking, possibly based on length of segment??
 
-        if (Math.abs(dot - 1) < 0.001) {
+        if (abs(dot - 1) < straightnessTolerance) {
             return false;
         }
 
@@ -87,7 +95,7 @@ public class IndoorWall implements Renderable {
             MapNode node = nodes.get(i);
 
             if (isCornerOrEnd(i)) {
-                wallSegmentNodes.add(new SegmentNodes(intermediateNodes, new LineSegmentXZ(prevNode.getPos(), node.getPos())));
+                wallSegmentNodes.add(new SegmentNodes(intermediateNodes, new LineSegmentXZ(prevNode.getPos(), node.getPos()), prevNode, node));
                 prevNode = node;
                 intermediateNodes = new ArrayList<>();
             } else {
@@ -102,17 +110,45 @@ public class IndoorWall implements Renderable {
 
         private List<MapNode> nodes;
         private LineSegmentXZ segment;
+        private MapNode startNode;
+        private MapNode endNode;
 
-        SegmentNodes(List<MapNode> allNodes, LineSegmentXZ segment){
+        SegmentNodes(List<MapNode> allNodes, LineSegmentXZ segment, MapNode startNode, MapNode endNode){
             nodes = allNodes;
             this.segment = segment;
+            this.startNode = startNode;
+            this.endNode = endNode;
         }
 
         List<MapNode> getNodes() { return nodes; }
 
         LineSegmentXZ getSegment() { return segment; }
 
-    }
+		public MapNode getStartNode() { return startNode; }
+
+		public MapNode getEndNode() { return endNode; }
+
+		public boolean containsMapSegment(LineSegmentXZ linSeg){
+
+        	List<VectorXZ> nodePositions = nodes.stream().map(n -> n.getPos()).collect(toList());
+
+        	if (linSeg.p1 == startNode.getPos() && nodePositions.contains(linSeg.p2)) {
+        		return true;
+			}
+
+        	if (linSeg.p2 == endNode.getPos() && nodePositions.contains(linSeg.p1)) {
+        		return true;
+			}
+
+        	if (nodePositions.contains(linSeg.p1) && nodePositions.contains(linSeg.p2)) {
+        		return true;
+			}
+
+        	return false;
+
+		}
+
+	}
 
     private class SegmentLevelPair {
 
@@ -213,12 +249,181 @@ public class IndoorWall implements Renderable {
 		List<VectorXYZ> limitedHeights = new ArrayList<>();
 
         for (VectorXZ intersection : intersections) {
-            limitedHeights.add(intersection.xyz(Math.min(data.getBuildingPart().getBuildingPartBaseEle() + data.getBuildingPart().getHeightWithoutRoof() + data.getBuildingPart().getRoof().getRoofHeightAt(intersection), heightAboveZero)));
+            limitedHeights.add(
+            		intersection.xyz(Math.min(data.getBuildingPart().getBuildingPartBaseEle()
+							+ data.getBuildingPart().getHeightWithoutRoof()
+							+ data.getBuildingPart().getRoof().getRoofHeightAt(intersection),
+							heightAboveZero)));
         }
 
         return limitedHeights;
 
     }
+
+	private class TagLineSegPair{
+
+    	private final TagSet tags;
+    	private final LineSegmentXZ lineSeg;
+
+    	TagLineSegPair(TagSet tags, LineSegmentXZ lineSeg){
+    		this.tags = tags;
+    		this.lineSeg = lineSeg;
+		}
+
+		TagSet getTags() { return tags; }
+
+		LineSegmentXZ getLineSegment() { return lineSeg; }
+
+	}
+
+    private List<VectorXZ> getNewEndPoint(SegmentNodes wallSegData, boolean end, int level){
+
+		MapNode endNode;
+		LineSegmentXZ wallSegSegment;
+		List<TagLineSegPair> allPairs = new ArrayList<>();
+
+		if (end) {
+			endNode = wallSegData.getEndNode();
+			wallSegSegment = wallSegData.getSegment();
+		} else {
+    		endNode = wallSegData.getStartNode();
+    		wallSegSegment = wallSegData.getSegment().reverse();
+		}
+
+
+		/* collect segments of connected areas */
+
+		List<MapArea> areas = new ArrayList<>(endNode.getAdjacentAreas());
+
+		for (int i = 0; i < areas.size(); i ++) {
+			List<MapAreaSegment> allSegments = new ArrayList<>(areas.get(i).getAreaSegments())
+					.stream()
+					.filter(v -> v.getEndNode() == endNode || v.getStartNode() == endNode)
+					.collect(toList());
+
+			for (MapAreaSegment s : allSegments) {
+				allPairs.add(new TagLineSegPair(areas.get(i).getTags(), s.getLineSegment()));
+			}
+		}
+
+
+		/* collect segments of connected ways */
+
+		List<MapWay> ways = new ArrayList<>(endNode.getConnectedWays());
+
+		for (int i = 0; i < ways.size(); i++) {
+			List<MapWaySegment> allSegments = new ArrayList<>(ways.get(i).getWaySegments())
+					.stream()
+					.filter(v -> v.getEndNode() == endNode || v.getStartNode() == endNode)
+					.collect(toList());
+
+			for (MapWaySegment s : allSegments) {
+				allPairs.add(new TagLineSegPair(ways.get(i).getTags(), s.getLineSegment()));
+			}
+		}
+
+
+		/* find closest wall clockwise and anticlockwise */
+
+		double maxAngle = 0;
+		LineSegmentXZ maxLineSegment = null;
+
+		double minAngle = 7;
+		LineSegmentXZ minLineSegment = null;
+
+		for (TagLineSegPair segmentPair : allPairs) {
+			LineSegmentXZ segment = segmentPair.getLineSegment();
+
+			if ((segmentPair.getTags().contains("indoor", "wall") || segmentPair.getTags().contains("indoor", "room"))
+					&& parseLevels(segmentPair.getTags().getValue("level")).stream().map(l -> data.getBuildingPart().levelConversion(l)).collect(toList()).contains(level)
+					&& !segment.equals(wallSegSegment)
+					&& !segment.equals(wallSegSegment.reverse())
+					&& !wallSegData.containsMapSegment(segment)
+					&& abs(abs(segment.getDirection().normalize().dot(wallSegSegment.getDirection().normalize())) - 1) >= straightnessTolerance) {
+
+				LineSegmentXZ segmentToCheck;
+
+				// make sure all connected segments are directed into segment end nodes
+
+				if (segment.p2 != wallSegSegment.p2) {
+					segmentToCheck = segment.reverse();
+				} else {
+					segmentToCheck = segment;
+				}
+
+				double clockwiseAngleBetween = segmentToCheck.getDirection().angle() - wallSegSegment.getDirection().angle();
+
+				clockwiseAngleBetween = clockwiseAngleBetween <= 0 ? TWO_PI + clockwiseAngleBetween : clockwiseAngleBetween;
+
+				if (maxAngle < clockwiseAngleBetween) {
+					maxAngle = clockwiseAngleBetween;
+					maxLineSegment = segmentToCheck;
+				}
+				if (clockwiseAngleBetween < minAngle) {
+					minAngle = clockwiseAngleBetween;
+					minLineSegment = segmentToCheck;
+				}
+
+			}
+		}
+
+
+		/* find intersections */
+
+		List<VectorXZ> result = new ArrayList<>();
+
+		List<VectorXZ> rightOffset = wallSegSegment.getVertexList().stream()
+				.map(v -> v.add(wallSegSegment.getDirection().rightNormal().mult(wallThickness)))
+				.collect(toList());
+		LineSegmentXZ offsetSegRight = new LineSegmentXZ(rightOffset.get(0), rightOffset.get(1));
+
+		List<VectorXZ> leftOffset = wallSegSegment.getVertexList().stream()
+				.map(v -> v.add(wallSegSegment.getDirection().rightNormal().mult(-wallThickness)))
+				.collect(toList());
+		LineSegmentXZ offsetSegLeft = new LineSegmentXZ(leftOffset.get(0), leftOffset.get(1));
+
+		VectorXZ tempResult = offsetSegRight.getVertexList().get(1);
+
+		if (maxLineSegment != null) {
+			VectorXZ intersection = GeometryUtil.getLineIntersection(offsetSegRight.p1,
+					offsetSegRight.getDirection(),
+					maxLineSegment.p2.add(maxLineSegment.getDirection().rightNormal().mult(-wallThickness)),
+					maxLineSegment.getDirection());
+			if (intersection != null) {
+				tempResult = intersection;
+			}
+		}
+
+		result.add(tempResult);
+
+		tempResult = offsetSegLeft.getVertexList().get(1);
+
+		if (minLineSegment != null) {
+			VectorXZ intersection = GeometryUtil.getLineIntersection(offsetSegLeft.p1,
+					offsetSegLeft.getDirection(),
+					minLineSegment.p2.add(minLineSegment.getDirection().rightNormal().mult(wallThickness)),
+					minLineSegment.getDirection());
+			if (intersection != null) {
+				tempResult = intersection;
+			}
+		}
+
+		result.add(tempResult);
+
+    	return result;
+
+	}
+
+    private List<VectorXZ> getNewEndPoints(SegmentNodes wallSegData, int level){
+
+    	List<VectorXZ> result = new ArrayList<>();
+
+		result.addAll(getNewEndPoint(wallSegData, false, level));
+		result.addAll(getNewEndPoint(wallSegData, true, level));
+
+		return result;
+
+	}
 
     @Override
     public void renderTo(Target target) {
@@ -229,6 +434,8 @@ public class IndoorWall implements Renderable {
 
         for (Integer level : data.getRenderableLevels()) {
 
+        	double ceilingHeight = baseEle + data.getBuildingPart().getLevelHeightAboveBase(level) + data.getBuildingPart().getLevelHeight(level);
+
             for (SegmentNodes wallSegData : wallSegmentNodes) {
 
                 SegmentLevelPair pair = new SegmentLevelPair(wallSegData.getSegment(), level);
@@ -237,35 +444,85 @@ public class IndoorWall implements Renderable {
 
                     allRenderedWallSegments.add(pair);
 
-                    List<VectorXZ> vectors = wallSegData.getSegment().getVertexList();
+					List<VectorXZ> endPoints = getNewEndPoints(wallSegData, level);
 
+					/* front wall surface */
 
-                    /* front wall surface */
+					List<VectorXZ> bottomPointsXZ = new ArrayList<>();
+					bottomPointsXZ.add(endPoints.get(3));
+					bottomPointsXZ.add(endPoints.get(0));
 
-                    List<VectorXYZ> bottomPoints = new ArrayList<>(listXYZ(vectors,
-                            baseEle + data.getBuildingPart().getLevelHeightAboveBase(level)));
+					List<VectorXYZ> bottomPoints = new ArrayList<>(listXYZ(bottomPointsXZ,
+							baseEle + data.getBuildingPart().getLevelHeightAboveBase(level)));
 
-                    List<VectorXYZ> topPoints = generateTopPoints(target ,vectors,
-                            baseEle + data.getBuildingPart().getLevelHeightAboveBase(level) + data.getBuildingPart().getLevelHeight(level));
+                    List<VectorXYZ> topPoints = generateTopPoints(target , bottomPointsXZ, ceilingHeight);
 
-                    // TODO check before generateTopPoints
+                    // TODO check if outside roof before generateTopPoints
 
                     if (topPoints.get(0).y < bottomPoints.get(0).y || topPoints.get(topPoints.size() - 1).y < bottomPoints.get(1).y) {
-                        topPoints =  new ArrayList<>(listXYZ(vectors,
-                                baseEle + data.getBuildingPart().getLevelHeightAboveBase(level) + data.getBuildingPart().getLevelHeight(level)));
+                        topPoints =  new ArrayList<>(listXYZ(bottomPointsXZ, ceilingHeight));
                     }
 
                     WallSurface mainSurface = new WallSurface(material, bottomPoints, topPoints);
 
                     /* back wall surface */
 
-                    List<VectorXYZ> backBottomPoints = new ArrayList<>(bottomPoints);
-                    List<VectorXYZ> backTopPoints = new ArrayList<>(topPoints);
+                    List<VectorXZ> backBottomPointsXZ = new ArrayList<>();
+                    backBottomPointsXZ.add(endPoints.get(2));
+                    backBottomPointsXZ.add(endPoints.get(1));
 
-                    Collections.reverse(backTopPoints);
-                    Collections.reverse(backBottomPoints);
+					Collections.reverse(backBottomPointsXZ);
+
+					List<VectorXYZ> backBottomPoints = new ArrayList<>(listXYZ(backBottomPointsXZ,
+							baseEle + data.getBuildingPart().getLevelHeightAboveBase(level)));
+
+                    List<VectorXYZ> backTopPoints = generateTopPoints(target , backBottomPointsXZ, ceilingHeight);
+
+					if (backTopPoints.get(0).y < backBottomPoints.get(0).y || backTopPoints.get(backTopPoints.size() - 1).y < backBottomPoints.get(1).y) {
+						backTopPoints =  new ArrayList<>(listXYZ(backBottomPointsXZ, ceilingHeight));
+					}
 
                     WallSurface backSurface = new WallSurface(material, backBottomPoints, backTopPoints);
+
+
+					/* generate wall edges */
+
+					WallSurface rightSurface = null;
+					WallSurface leftSurface = null;
+
+					// TODO avoid needing a try
+
+					try {
+
+						List<VectorXZ> bottomVertexLoop = new ArrayList<>(endPoints);
+						bottomVertexLoop.add(endPoints.get(0));
+
+						SimplePolygonXZ bottomPolygonXZ = new SimplePolygonXZ(bottomVertexLoop);
+						Collection<TriangleXYZ> bottomTriangles = TriangulationUtil.
+								triangulate(bottomPolygonXZ.asPolygonWithHolesXZ())
+								.stream()
+								.map(t -> t.makeClockwise().xyz(baseEle + data.getBuildingPart().getLevelHeightAboveBase(level)))
+								.collect(toList());
+
+						Collection<TriangleXYZ> tempTopTriangles = TriangulationUtil.
+								triangulate(bottomPolygonXZ.asPolygonWithHolesXZ())
+								.stream()
+								.map(t -> t.makeCounterclockwise().xyz(ceilingHeight))
+								.collect(toList());
+
+						target.drawTriangles(material, bottomTriangles, triangleTexCoordLists(bottomTriangles, material, GLOBAL_X_Z));
+						target.drawTriangles(material, tempTopTriangles, triangleTexCoordLists(tempTopTriangles, material, GLOBAL_X_Z));
+
+
+						rightSurface = new WallSurface(material,
+								Arrays.asList(bottomPoints.get(1), backBottomPoints.get(0)),
+								Arrays.asList(topPoints.get(0), backTopPoints.get(backBottomPoints.size() - 1)));
+
+						leftSurface = new WallSurface(material,
+								Arrays.asList(backBottomPoints.get(1), bottomPoints.get(0)),
+								Arrays.asList(backTopPoints.get(0), topPoints.get(topPoints.size() - 1)));
+
+					} catch (InvalidGeometryException e) {}
 
                     /* add windows that aren't on vertices */
 
@@ -310,9 +567,13 @@ public class IndoorWall implements Renderable {
 
                     /* draw wall */
 
-                    if (mainSurface != null) {
+                    if (mainSurface != null && backSurface != null) {
                         mainSurface.renderTo(target, new VectorXZ(0, -floorHeight), false, 0);
                         backSurface.renderTo(target, new VectorXZ(0, -floorHeight), false, 0);
+                        if (leftSurface != null && rightSurface != null) {
+							rightSurface.renderTo(target, new VectorXZ(0, -floorHeight), false, 0);
+							leftSurface.renderTo(target, new VectorXZ(0, -floorHeight), false, 0);
+						}
                     }
                 }
 

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
@@ -16,7 +16,7 @@ import javax.sound.sampled.Line;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static java.lang.Math.abs;
+import static java.lang.Math.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
@@ -796,6 +796,9 @@ public class IndoorWall implements Renderable {
 
                     /* add windows that aren't on vertices */
 
+					LineSegmentXZ frontLineSegment =  new LineSegmentXZ(endPoints.get(3), endPoints.get(0));
+					LineSegmentXZ backLineSegment =  new LineSegmentXZ(endPoints.get(1), endPoints.get(2));
+
                     for (MapNode node : wallSegData.getNodes()) {
 
 						Set<Integer> objectLevels = new HashSet<>();
@@ -806,9 +809,8 @@ public class IndoorWall implements Renderable {
 								.map(l -> data.getBuildingPart().levelConversion(l))
 								.collect(Collectors.toSet());
 
-						Double offset = wallSegData.getSegment().getLength() - wallSegData.segment.offsetOf(wallSegData.segment.closestPoint(node.getPos()));
-						VectorXZ posFront = new VectorXZ(offset, 0);
-						VectorXZ posback = new VectorXZ(wallSegData.segment.getLength() - offset, 0);
+						VectorXZ posFront = new VectorXZ(frontLineSegment.offsetOf(frontLineSegment.closestPoint(node.getPos())), 0);
+						VectorXZ posback = new VectorXZ(backLineSegment.offsetOf(backLineSegment.closestPoint(node.getPos())), 0);
 
 						if (objectLevels.contains(level)) {
 
@@ -820,8 +822,8 @@ public class IndoorWall implements Renderable {
                                 TagSet windowTags = inheritTags(node.getTags(), data.getTags());
                                 WindowParameters params = new WindowParameters(windowTags, data.getBuildingPart().getLevelHeight(level));
 
-                                GeometryWindow windowFront = new GeometryWindow(new VectorXZ(offset, params.breast), params, transparent);
-                                GeometryWindow windowBack = new GeometryWindow(new VectorXZ(wallSegData.segment.getLength() - offset, params.breast), params, transparent);
+                                GeometryWindow windowFront = new GeometryWindow(new VectorXZ(posFront.x, params.breast), params, transparent);
+                                GeometryWindow windowBack = new GeometryWindow(new VectorXZ(posback.x, params.breast), params, transparent);
 
                                 mainSurface.addElementIfSpaceFree(windowFront);
                                 backSurface.addElementIfSpaceFree(windowBack);

--- a/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/indoor/IndoorWall.java
@@ -193,7 +193,7 @@ public class IndoorWall implements Renderable {
 								.map(l -> data.getBuildingPart().levelConversion(l))
 								.collect(Collectors.toSet());
 
-						Double offset = wallSegData.segment.offsetOf(node.getPos());
+						Double offset = wallSegData.segment.offsetOf(wallSegData.segment.closestPoint(node.getPos()));
 						VectorXZ posFront = new VectorXZ(offset, 0);
 						VectorXZ posback = new VectorXZ(wallSegData.segment.getLength() - offset, 0);
 
@@ -201,8 +201,6 @@ public class IndoorWall implements Renderable {
 
 							if (node.getTags().containsKey("window")
                                 && !node.getTags().contains("window", "no")) {
-
-
 
                                 TagSet windowTags = inheritTags(node.getTags(), data.getTags());
                                 WindowParameters params = new WindowParameters(windowTags, data.getBuildingPart().getLevelHeight(level));

--- a/src/main/java/org/osm2world/core/world/modules/building/roof/HeightfieldRoof.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/roof/HeightfieldRoof.java
@@ -34,9 +34,6 @@ abstract public class HeightfieldRoof extends Roof {
 		super(originalPolygon, tags, height, material);
 	}
 
-	/** returns segments within the roof polygon that define ridges or edges of the roof */
-	public abstract Collection<LineSegmentXZ> getInnerSegments();
-
 	/** returns segments within the roof polygon that define apex nodes of the roof */
 	public abstract Collection<VectorXZ> getInnerPoints();
 

--- a/src/main/java/org/osm2world/core/world/modules/building/roof/Roof.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/roof/Roof.java
@@ -1,12 +1,15 @@
 package org.osm2world.core.world.modules.building.roof;
 
 import org.osm2world.core.map_data.data.TagSet;
+import org.osm2world.core.math.LineSegmentXZ;
 import org.osm2world.core.math.PolygonWithHolesXZ;
 import org.osm2world.core.math.VectorXZ;
 import org.osm2world.core.target.Renderable;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.material.Material;
 import org.osm2world.core.world.modules.building.BuildingPart;
+
+import java.util.Collection;
 
 /** the roof of a {@link BuildingPart} */
 abstract public class Roof {
@@ -39,6 +42,9 @@ abstract public class Roof {
 	 * returns roof height at a position. Must be non-negative for sensible inputs.
 	 */
 	abstract public double getRoofHeightAt(VectorXZ coord);
+
+	/** returns segments within the roof polygon that define ridges or edges of the roof */
+	public abstract Collection<LineSegmentXZ> getInnerSegments();
 
 	/**
 	 * renders the roof. The same as {@link Renderable#renderTo(Target)},

--- a/src/main/java/org/osm2world/core/world/modules/building/roof/SpindleRoof.java
+++ b/src/main/java/org/osm2world/core/world/modules/building/roof/SpindleRoof.java
@@ -8,14 +8,12 @@ import static java.util.Collections.*;
 import static org.osm2world.core.math.VectorXYZ.Z_UNIT;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.osm2world.core.map_data.data.TagSet;
-import org.osm2world.core.math.PolygonWithHolesXZ;
-import org.osm2world.core.math.SimplePolygonXZ;
-import org.osm2world.core.math.VectorXYZ;
-import org.osm2world.core.math.VectorXZ;
+import org.osm2world.core.math.*;
 import org.osm2world.core.math.shapes.ShapeXZ;
 import org.osm2world.core.target.Target;
 import org.osm2world.core.target.common.TextureData;
@@ -35,6 +33,12 @@ abstract public class SpindleRoof extends Roof {
 	@Override
 	public double getRoofHeightAt(VectorXZ pos) {
 		return 0;
+	}
+
+	// TODO needs implementing
+	@Override
+	public Collection<LineSegmentXZ> getInnerSegments(){
+		return emptyList();
 	}
 
 	@Override

--- a/src/main/java/org/osm2world/viewer/control/actions/ResetCameraAction.java
+++ b/src/main/java/org/osm2world/viewer/control/actions/ResetCameraAction.java
@@ -46,7 +46,7 @@ public class ResetCameraAction extends AbstractAction implements Observer {
 
 		MapData mapData = data.getConversionResults().getMapData();
 
-		VectorXZ camLookAt = mapData.getCenter();
+		VectorXZ camLookAt = mapData.getBoundary().center();
 
 		renderOptions.camera = new Camera();
 		renderOptions.camera.setCamera(camLookAt.x, 1000, camLookAt.z-1000,

--- a/src/main/java/org/osm2world/viewer/view/ViewerFrame.java
+++ b/src/main/java/org/osm2world/viewer/view/ViewerFrame.java
@@ -55,6 +55,8 @@ import org.osm2world.viewer.control.navigation.DefaultNavigation;
 import org.osm2world.viewer.model.Data;
 import org.osm2world.viewer.model.MessageManager;
 import org.osm2world.viewer.model.RenderOptions;
+import org.osm2world.viewer.view.debug.AttachmentConnectorDebugView;
+import org.osm2world.viewer.view.debug.AttachmentSurfaceDebugView;
 import org.osm2world.viewer.view.debug.ClearingDebugView;
 import org.osm2world.viewer.view.debug.DebugView;
 import org.osm2world.viewer.view.debug.EleConnectorDebugView;
@@ -185,6 +187,10 @@ public class ViewerFrame extends JFrame {
 
 			initAndAddDebugView(subMenu, -1, false,
 					new TerrainBoundaryAABBDebugView());
+			initAndAddDebugView(subMenu, -1, false,
+					new AttachmentSurfaceDebugView());
+			initAndAddDebugView(subMenu, -1, false,
+					new AttachmentConnectorDebugView());
 			initAndAddDebugView(subMenu, VK_L, false,
 					new ClearingDebugView());
 			initAndAddDebugView(subMenu, VK_D, false,

--- a/src/main/java/org/osm2world/viewer/view/debug/AttachmentConnectorDebugView.java
+++ b/src/main/java/org/osm2world/viewer/view/debug/AttachmentConnectorDebugView.java
@@ -1,0 +1,56 @@
+package org.osm2world.viewer.view.debug;
+
+import static java.awt.Color.*;
+import static org.osm2world.core.math.VectorXZ.Z_UNIT;
+
+import java.awt.Color;
+
+import org.osm2world.core.math.VectorXYZ;
+import org.osm2world.core.target.common.material.ImmutableMaterial;
+import org.osm2world.core.target.common.material.Material.Interpolation;
+import org.osm2world.core.target.jogl.JOGLTarget;
+import org.osm2world.core.world.attachment.AttachmentConnector;
+import org.osm2world.core.world.data.WorldObject;
+
+public class AttachmentConnectorDebugView extends DebugView {
+
+	private final Color ATTACHED_COLOUR = GREEN;
+	private final Color FAILED_COLOUR = RED;
+
+	@Override
+	public String getDescription() {
+		return "shows connectors that attach objects to surfaces";
+	}
+
+	@Override
+	public boolean canBeUsed() {
+		return map != null;
+	}
+
+	@Override
+	protected void fillTarget(JOGLTarget target) {
+
+		for (WorldObject object : map.getWorldObjects()) {
+			for (AttachmentConnector connector : object.getAttachmentConnectors()) {
+
+				if (connector.isAttached()) {
+
+					VectorXYZ pos = connector.getAttachedPos();
+					target.drawBox(new ImmutableMaterial(Interpolation.FLAT, ATTACHED_COLOUR),
+							pos.addY(-0.1), Z_UNIT, 0.2, 0.2, 0.2);
+					drawArrow(target, ATTACHED_COLOUR, 0.2f, pos,
+							pos.add(connector.getAttachedSurfaceNormal()));
+
+				} else {
+
+					target.drawBox(new ImmutableMaterial(Interpolation.FLAT, FAILED_COLOUR),
+							connector.originalPos.addY(-0.1), Z_UNIT, 0.2, 0.2, 0.2);
+
+				}
+
+			}
+		}
+
+	}
+
+}

--- a/src/main/java/org/osm2world/viewer/view/debug/AttachmentSurfaceDebugView.java
+++ b/src/main/java/org/osm2world/viewer/view/debug/AttachmentSurfaceDebugView.java
@@ -1,0 +1,93 @@
+package org.osm2world.viewer.view.debug;
+
+import static java.awt.Color.ORANGE;
+import static java.util.Collections.emptyList;
+
+import java.awt.Color;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.osm2world.core.math.PolygonXYZ;
+import org.osm2world.core.math.VectorXYZ;
+import org.osm2world.core.target.common.material.ImmutableMaterial;
+import org.osm2world.core.target.common.material.Material;
+import org.osm2world.core.target.common.material.Material.Interpolation;
+import org.osm2world.core.target.jogl.JOGLTarget;
+import org.osm2world.core.world.attachment.AttachmentSurface;
+import org.osm2world.core.world.data.WorldObject;
+
+public class AttachmentSurfaceDebugView extends DebugView {
+
+	private static final Color BASE_ELE_COLOR = ORANGE;
+
+	private final Map<String, Color> surfaceTypeColors = new HashMap<>();
+
+	public AttachmentSurfaceDebugView() {
+
+		super();
+
+		surfaceTypeColors.put("wall", new Color(1.0f, 1.0f, 0));
+		surfaceTypeColors.put("roof", new Color(1.0f, 0.8f, 0.8f));
+
+	}
+
+	@Override
+	public String getDescription() {
+		return "shows surfaces that other WorldObjects can attach themselves to";
+	}
+
+	@Override
+	public boolean canBeUsed() {
+		return map != null;
+	}
+
+	@Override
+	protected void fillTarget(JOGLTarget target) {
+
+		for (WorldObject object : map.getWorldObjects()) {
+			for (AttachmentSurface surface : object.getAttachmentSurfaces()) {
+
+				String type = surface.getTypes().iterator().next();
+				Color color = getOrCreateColor(type);
+
+				for (PolygonXYZ face : surface.getFaces()) {
+
+					Material material = new ImmutableMaterial(Interpolation.FLAT, color);
+					target.drawConvexPolygon(material, face.getVertexLoop(), emptyList());
+
+					//draw base ele
+					for (int i = 0; i < face.size(); i++) {
+						VectorXYZ v1 = face.getVertexLoop().get(i);
+						VectorXYZ v2 = face.getVertexLoop().get(i + 1);
+						v1 = v1.y(surface.getBaseEleAt(v1.xz()));
+						v2 = v2.y(surface.getBaseEleAt(v2.xz()));
+						target.drawLineStrip(BASE_ELE_COLOR, 2, v1, v2);
+					}
+
+				}
+
+			}
+		}
+
+	}
+
+	private Color getOrCreateColor(String surfaceType) {
+
+		if (!surfaceTypeColors.containsKey(surfaceType)) {
+
+			Random random = new Random(surfaceTypeColors.size());
+			float h = random.nextFloat();
+			float s = (random.nextInt(2000) + 1000) / 10000f;
+			float b = 0.9f;
+			final Color newColor = Color.getHSBColor(h, s, b);
+
+			surfaceTypeColors.put(surfaceType, newColor);
+
+		}
+
+		return surfaceTypeColors.get(surfaceType);
+
+	}
+
+}

--- a/src/test/java/org/osm2world/core/math/AxisAlignedRectangleTest.java
+++ b/src/test/java/org/osm2world/core/math/AxisAlignedRectangleTest.java
@@ -1,0 +1,26 @@
+package org.osm2world.core.math;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.osm2world.core.math.AxisAlignedRectangleXZ.bboxUnion;
+
+import org.junit.Test;
+
+public class AxisAlignedRectangleTest {
+
+	@Test
+	public void testBboxUnion() {
+
+		AxisAlignedRectangleXZ box1 = new AxisAlignedRectangleXZ(5, 5, 10, 10);
+		AxisAlignedRectangleXZ box2 = new AxisAlignedRectangleXZ(7, 3, 20, 10);
+
+		AxisAlignedRectangleXZ result = bboxUnion(asList(box1, box2));
+
+		assertEquals(5, result.minX, 0);
+		assertEquals(3, result.minZ, 0);
+		assertEquals(20, result.maxX, 0);
+		assertEquals(10, result.maxZ, 0);
+
+	}
+
+}

--- a/src/test/java/org/osm2world/core/math/FaceXYZTest.java
+++ b/src/test/java/org/osm2world/core/math/FaceXYZTest.java
@@ -1,0 +1,82 @@
+package org.osm2world.core.math;
+
+import static java.util.Arrays.asList;
+import static org.osm2world.core.math.GeometryUtil.closeLoop;
+import static org.osm2world.core.test.TestUtil.assertAlmostEquals;
+
+import org.junit.Test;
+
+public class FaceXYZTest {
+
+	@Test
+	public void testToFacePlane_xzParallel() {
+
+		FaceXYZ face = new FaceXYZ(closeLoop(asList(
+				new VectorXYZ(-1, 20, -1),
+				new VectorXYZ(+1, 20, -1),
+				new VectorXYZ(+1, 20, +1),
+				new VectorXYZ(-1, 20, +1)
+				)));
+
+		SimplePolygonXZ faceInPlane = face.toFacePlane(face);
+		assertAlmostEquals(face.getSimpleXZPolygon(), faceInPlane);
+		assertAlmostEquals(new VectorXZ(10, 22), face.toFacePlane(new VectorXYZ(10, 40, 22)));
+
+		PolygonXYZ faceBackInXYZ = face.fromFacePlane(faceInPlane);
+		assertAlmostEquals(face, faceBackInXYZ);
+
+	}
+
+	@Test
+	public void testToFacePlane_xzParallelFlipped() {
+
+		FaceXYZ face = new FaceXYZ(closeLoop(asList(
+				new VectorXYZ(-1, -3.5, -1),
+				new VectorXYZ(-1, -3.5, +1),
+				new VectorXYZ(+1, -3.5,  0)
+				)));
+
+		SimplePolygonXZ faceInPlane = face.toFacePlane(face);
+		PolygonXYZ faceBackInXYZ = face.fromFacePlane(faceInPlane);
+		assertAlmostEquals(face, faceBackInXYZ);
+
+	}
+
+	@Test
+	public void testToFacePlane_verticalFace() {
+
+		FaceXYZ face = new FaceXYZ(closeLoop(asList(
+				new VectorXYZ(-1, -1, 42),
+				new VectorXYZ(+1, -1, 42),
+				new VectorXYZ(+1, +1, 42),
+				new VectorXYZ(-1, +1, 42)
+				)));
+
+		SimplePolygonXZ faceInPlane = face.toFacePlane(face);
+		PolygonXYZ faceBackInXYZ = face.fromFacePlane(faceInPlane);
+		assertAlmostEquals(face, faceBackInXYZ);
+
+	}
+
+	@Test
+	public void testClosestPoint_verticalFace() {
+
+		FaceXYZ face = new FaceXYZ(closeLoop(asList(
+				new VectorXYZ(-1, -1, 22),
+				new VectorXYZ(-1,  0, 22),
+				new VectorXYZ(-1, +1, 22),
+				new VectorXYZ(+1, +1, 22),
+				new VectorXYZ(+1, -1, 22),
+				new VectorXYZ(-1, -1, 22))));
+
+			// within face
+			assertAlmostEquals(new VectorXYZ(0.2, 0.2, 22), face.closestPoint(new VectorXYZ(0.2, 0.2, 0)));
+			assertAlmostEquals(new VectorXYZ(-1, -1, 22), face.closestPoint(new VectorXYZ(-1, -1, 50)));
+
+			// outside face
+			assertAlmostEquals(new VectorXYZ(-1, -1, 22), face.closestPoint(new VectorXYZ(-10, -10, 22)));
+			assertAlmostEquals(new VectorXYZ(1, 0.5, 22), face.closestPoint(new VectorXYZ(26, 0.5, 33)));
+
+	}
+
+}

--- a/src/test/java/org/osm2world/core/math/SimplePolygonXZTest.java
+++ b/src/test/java/org/osm2world/core/math/SimplePolygonXZTest.java
@@ -82,6 +82,19 @@ public class SimplePolygonXZTest {
 	}
 
 	@Test
+	public void testClosestPoint() {
+
+		// within polygon
+		assertAlmostEquals(new VectorXZ(0.2, 0.2), p1.closestPoint(new VectorXZ(0.2, 0.2)));
+		assertAlmostEquals(new VectorXZ(-1, -1), p1.closestPoint(new VectorXZ(-1, -1)));
+
+		// outside polygon
+		assertAlmostEquals(new VectorXZ(-1, -1), p1.closestPoint(new VectorXZ(-10, -10)));
+		assertAlmostEquals(new VectorXZ(1, 0.5), p1.closestPoint(new VectorXZ(26, 0.5)));
+
+	}
+
+	@Test
 	public void testShift() {
 
 		SimplePolygonShapeXZ shiftP = p1.shift(VectorXZ.X_UNIT);

--- a/src/test/java/org/osm2world/core/math/algorithms/Earcut4JTriangulationTest.java
+++ b/src/test/java/org/osm2world/core/math/algorithms/Earcut4JTriangulationTest.java
@@ -2,11 +2,13 @@ package org.osm2world.core.math.algorithms;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static org.osm2world.core.math.GeometryUtil.closeLoop;
 import static org.osm2world.core.test.TestUtil.assertSameCyclicOrder;
 
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.osm2world.core.math.SimplePolygonXZ;
 import org.osm2world.core.math.TriangleXZ;
@@ -17,11 +19,10 @@ public class Earcut4JTriangulationTest {
 	@Test
 	public void testTriangulate_triangle() {
 
-		SimplePolygonXZ outer = new SimplePolygonXZ(asList(
+		SimplePolygonXZ outer = new SimplePolygonXZ(closeLoop(
 				new VectorXZ(-1, 0),
 				new VectorXZ(1, 0),
-				new VectorXZ(0, 1),
-				new VectorXZ(-1, 0)
+				new VectorXZ(0, 1)
 				));
 
 		List<TriangleXZ> result = Earcut4JTriangulationUtil.triangulate(outer, emptyList());
@@ -34,11 +35,10 @@ public class Earcut4JTriangulationTest {
 	@Test
 	public void testTriangulate_triangleWithPoint() {
 
-		SimplePolygonXZ outer = new SimplePolygonXZ(asList(
+		SimplePolygonXZ outer = new SimplePolygonXZ(closeLoop(
 				new VectorXZ(-1, 0),
 				new VectorXZ(1, 0),
-				new VectorXZ(0, 1),
-				new VectorXZ(-1, 0)
+				new VectorXZ(0, 1)
 				));
 
 		VectorXZ point = new VectorXZ(0, 0.3);
@@ -52,12 +52,11 @@ public class Earcut4JTriangulationTest {
 	@Test
 	public void testTriangulate_rectangle() {
 
-		SimplePolygonXZ outer = new SimplePolygonXZ(asList(
+		SimplePolygonXZ outer = new SimplePolygonXZ(closeLoop(
 				new VectorXZ(0, 0),
 				new VectorXZ(1, 0),
 				new VectorXZ(1, 1),
-				new VectorXZ(0, 1),
-				new VectorXZ(0, 0)
+				new VectorXZ(0, 1)
 				));
 
 		List<TriangleXZ> result = Earcut4JTriangulationUtil.triangulate(outer, emptyList());
@@ -69,25 +68,46 @@ public class Earcut4JTriangulationTest {
 	@Test
 	public void testTriangulate_rectangleWithHole() {
 
-		SimplePolygonXZ outer = new SimplePolygonXZ(asList(
+		SimplePolygonXZ outer = new SimplePolygonXZ(closeLoop(
 				new VectorXZ(0, 0),
 				new VectorXZ(1, 0),
 				new VectorXZ(1, 1),
-				new VectorXZ(0, 1),
-				new VectorXZ(0, 0)
+				new VectorXZ(0, 1)
 				));
 
-		SimplePolygonXZ inner = new SimplePolygonXZ(asList(
+		SimplePolygonXZ inner = new SimplePolygonXZ(closeLoop(
 				new VectorXZ(0.25, 0.25),
 				new VectorXZ(0.75, 0.25),
 				new VectorXZ(0.75, 0.75),
-				new VectorXZ(0.25, 0.75),
-				new VectorXZ(0.25, 0.25)
+				new VectorXZ(0.25, 0.75)
 				));
 
 		List<TriangleXZ> result = Earcut4JTriangulationUtil.triangulate(outer, asList(inner));
 
 		assertEquals(8, result.size());
+
+	}
+
+	@Ignore // TODO: fix the triangulation errors that happen with a sufficient number of inner points
+	@Test
+	public void testTriangulate_multiplePoints() {
+
+		SimplePolygonXZ outer = new SimplePolygonXZ(closeLoop(
+				new VectorXZ(-10, -10),
+				new VectorXZ(+10, -10),
+				new VectorXZ(+10, +10),
+				new VectorXZ(-10, +10)
+				));
+
+		List<VectorXZ> points = asList(
+				new VectorXZ(-5, -5),
+				new VectorXZ(-3, 4),
+				new VectorXZ(3, 3),
+				new VectorXZ(5, -2));
+
+		List<TriangleXZ> result = Earcut4JTriangulationUtil.triangulate(outer, emptyList(), points);
+
+		assertTrue(result.size() > 5);
 
 	}
 

--- a/src/test/java/org/osm2world/core/test/TestMapDataGenerator.java
+++ b/src/test/java/org/osm2world/core/test/TestMapDataGenerator.java
@@ -1,5 +1,7 @@
 package org.osm2world.core.test;
 
+import static org.osm2world.core.math.GeometryUtil.closeLoop;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -14,8 +16,6 @@ import org.osm2world.core.map_data.data.TagSet;
 import org.osm2world.core.map_data.data.overlaps.MapOverlapAA;
 import org.osm2world.core.map_data.data.overlaps.MapOverlapType;
 import org.osm2world.core.math.VectorXZ;
-
-import static org.osm2world.core.map_data.data.overlaps.MapOverlapType.SHARE_SEGMENT;
 
 /**
  * creates {@link MapElement}s for tests.
@@ -70,18 +70,6 @@ public class TestMapDataGenerator {
 	/** returns a {@link MapData} object containing all the elements created so far */
 	public MapData createMapData() {
 		return new MapData(nodes, ways, areas, relations, null);
-	}
-
-	/**
-	 * returns the list itself if the last element of the list equals the first;
-	 * otherwise, returns a list that's the same except with the first element appended to the end.
-	 */
-	private <T> List<T> closeLoop(List<T> list) {
-		if (!list.get(0).equals(list.get(list.size() - 1))) {
-			list = new ArrayList<>(list);
-			list.add(list.get(0));
-		}
-		return list;
 	}
 
 	/**

--- a/src/test/java/org/osm2world/core/test/TestUtil.java
+++ b/src/test/java/org/osm2world/core/test/TestUtil.java
@@ -10,8 +10,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.osm2world.core.math.PolygonXYZ;
 import org.osm2world.core.math.VectorXYZ;
 import org.osm2world.core.math.VectorXZ;
+import org.osm2world.core.math.shapes.SimplePolygonShapeXZ;
 
 public final class TestUtil {
 
@@ -90,6 +92,16 @@ public final class TestUtil {
 
 	}
 
+	public static final void assertAlmostEqualsXYZ(List<VectorXYZ> expected, List<VectorXYZ> actual) {
+
+		assertSame(expected.size(), actual.size());
+
+		for (int i = 0; i < expected.size(); i++) {
+			assertAlmostEquals(expected.get(i), actual.get(i));
+		}
+
+	}
+
 	/**
 	 * @throws AssertionError unless the two sets contain the "same" vectors
 	 * (by the standards of {@link #assertAlmostEquals(VectorXZ, VectorXZ)})
@@ -104,6 +116,14 @@ public final class TestUtil {
 			}
 		}
 
+	}
+
+	public static final void assertAlmostEquals(SimplePolygonShapeXZ expected, SimplePolygonShapeXZ actual) {
+		assertAlmostEquals(expected.getVertexListNoDup(), actual.getVertexListNoDup());
+	}
+
+	public static final void assertAlmostEquals(PolygonXYZ expected, PolygonXYZ actual) {
+		assertAlmostEqualsXYZ(expected.getVertices(), actual.getVertices());
 	}
 
 	/**

--- a/src/test/java/org/osm2world/core/world/modules/building/BuildingPartTest.java
+++ b/src/test/java/org/osm2world/core/world/modules/building/BuildingPartTest.java
@@ -1,24 +1,21 @@
 package org.osm2world.core.world.modules.building;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
-import static org.osm2world.core.map_data.data.overlaps.MapOverlapType.SHARE_SEGMENT;
-import static org.osm2world.core.test.TestMapDataGenerator.addOverlapAA;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationFactory;
 import org.junit.Test;
 import org.osm2world.core.map_data.data.MapArea;
 import org.osm2world.core.map_data.data.MapNode;
 import org.osm2world.core.map_data.data.MapWay;
 import org.osm2world.core.map_data.data.TagSet;
-import org.osm2world.core.map_data.data.overlaps.MapOverlapAA;
-import org.osm2world.core.map_data.data.overlaps.MapOverlapType;
 import org.osm2world.core.test.TestMapDataGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.osm2world.core.map_data.data.overlaps.MapOverlapType.SHARE_SEGMENT;
+import static org.osm2world.core.test.TestMapDataGenerator.addOverlapAA;
 
 public class BuildingPartTest {
 

--- a/src/test/java/org/osm2world/core/world/modules/building/Indoor/IndoorWallTest.java
+++ b/src/test/java/org/osm2world/core/world/modules/building/Indoor/IndoorWallTest.java
@@ -1,0 +1,124 @@
+package org.osm2world.core.world.modules.building.Indoor;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.junit.Test;
+import org.osm2world.core.map_data.data.MapArea;
+import org.osm2world.core.map_data.data.MapNode;
+import org.osm2world.core.map_data.data.MapWay;
+import org.osm2world.core.map_data.data.TagSet;
+import org.osm2world.core.math.LineSegmentXZ;
+import org.osm2world.core.math.VectorXZ;
+import org.osm2world.core.test.TestMapDataGenerator;
+import org.osm2world.core.world.modules.building.Building;
+import org.osm2world.core.world.modules.building.BuildingPart;
+import org.osm2world.core.world.modules.building.indoor.IndoorObjectData;
+import org.osm2world.core.world.modules.building.indoor.IndoorWall;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Math.PI;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class IndoorWallTest {
+
+	@Test
+	public void testGetNewEndPoints(){
+
+		TestMapDataGenerator generator = new TestMapDataGenerator();
+
+		/* generate building part */
+
+		List<MapNode> buildingNodes = new ArrayList<>(asList(
+				generator.createNode(-10, -5),
+				generator.createNode(  0, -5),
+				generator.createNode(+10, -5),
+				generator.createNode(+10, +5),
+				generator.createNode(-10, +5)));
+
+		buildingNodes.add(buildingNodes.get(0));
+
+		MapArea buildingPartArea = generator.createWayArea(buildingNodes, TagSet.of("building", "yes", "building:levels", "5", "height", "12.5"));
+		Building building = new Building(buildingPartArea, new BaseConfiguration());
+		BuildingPart buildingPart = building.getParts().get(0);
+
+		/* generate wall */
+
+		List<MapNode> wallNodes = new ArrayList<>(asList(
+				generator.createNode(-9, -4),
+				generator.createNode(+9, -4),
+				generator.createNode( 0, 4),
+				generator.createNode( 0, -3)));
+
+		MapWay wallWay = generator.createWay(asList(wallNodes.get(0), wallNodes.get(2)), TagSet.of("indoor", "wall", "level", "2"));
+		LineSegmentXZ wallWayLineSegment = new LineSegmentXZ(wallNodes.get(0).getPos(), wallNodes.get(2).getPos());
+
+		VectorXZ startNodePos = wallNodes.get(0).getPos();
+		VectorXZ endNodePos = wallNodes.get(2).getPos();
+
+		IndoorWall wall = new IndoorWall(new IndoorObjectData(buildingPart, wallWay.getWaySegments().get(0)));
+
+		/* test basic case */
+
+		List<VectorXZ> endPointsList = wall.getNewEndPoints(wall.getWallSegmentNodes().get(0),2, 5, 7.5);
+
+		VectorXZ wallWayRightNormal = wallWayLineSegment.getDirection().rightNormal();
+
+		assertEquals(startNodePos.add(wallWayRightNormal.mult(-wall.getWallThickness())), endPointsList.get(0));
+		assertEquals(startNodePos.add(wallWayRightNormal.mult(wall.getWallThickness())), endPointsList.get(1));
+		assertEquals(endNodePos.add(wallWayRightNormal.mult(wall.getWallThickness())), endPointsList.get(2));
+		assertEquals(endNodePos.add(wallWayRightNormal.mult(-wall.getWallThickness())), endPointsList.get(3));
+
+		/* test intersection of 2 line segments */
+
+		MapWay secondWallWay =  generator.createWay(asList(wallNodes.get(2), wallNodes.get(1)), TagSet.of("indoor", "wall", "level", "2"));
+		LineSegmentXZ secondWallWayLineSegment = new LineSegmentXZ(wallNodes.get(2).getPos(), wallNodes.get(1).getPos());
+
+		VectorXZ secondStartNodePos = wallNodes.get(2).getPos();
+		VectorXZ secondEndNodePos = wallNodes.get(1).getPos();
+		VectorXZ secondRightNormal = secondWallWayLineSegment.getDirection().rightNormal();
+
+		IndoorWall secondWall = new IndoorWall(new IndoorObjectData(buildingPart, secondWallWay.getWaySegments().get(0)));
+
+
+		List<VectorXZ> secondEndPointsList = secondWall.getNewEndPoints(secondWall.getWallSegmentNodes().get(0),2, 5, 7.5);
+
+		double offset = secondWall.getWallThickness() / Math.sin(PI/2);
+
+		assertEquals(0, new VectorXZ(0, 4 - offset).subtract(secondEndPointsList.get(1)).length(), 0.05);
+		assertEquals(0, new VectorXZ(0, 4 + offset).subtract(secondEndPointsList.get(0)).length(), 0.05);
+		assertEquals(secondEndNodePos.add(secondRightNormal.mult(wall.getWallThickness())), secondEndPointsList.get(2));
+		assertEquals(secondEndNodePos.add(secondRightNormal.mult(-wall.getWallThickness())), secondEndPointsList.get(3));
+
+		endPointsList = wall.getNewEndPoints(wall.getWallSegmentNodes().get(0),2, 5, 7.5);
+
+		assertEquals(0, endPointsList.get(3).subtract(secondEndPointsList.get(0)).length(), 0.05);
+		assertEquals(0, endPointsList.get(2).subtract(secondEndPointsList.get(1)).length(), 0.05);
+
+		/* test intersections for line not on the same level */
+
+		MapWay thirdWallWay =  generator.createWay(asList(wallNodes.get(2), wallNodes.get(3)), TagSet.of("indoor", "wall", "level", "3"));
+		LineSegmentXZ thirdWallWayLineSegment = new LineSegmentXZ(wallNodes.get(2).getPos(), wallNodes.get(3).getPos());
+
+		VectorXZ thirdStartNodePos = wallNodes.get(2).getPos();
+		VectorXZ thirdEndNodePos = wallNodes.get(3).getPos();
+		VectorXZ thirdRightNormal = thirdWallWayLineSegment.getDirection().rightNormal();
+
+		IndoorWall thirdWall = new IndoorWall(new IndoorObjectData(buildingPart, thirdWallWay.getWaySegments().get(0)));
+
+		endPointsList = wall.getNewEndPoints(wall.getWallSegmentNodes().get(0),2, 5, 7.5);
+		secondEndPointsList = secondWall.getNewEndPoints(secondWall.getWallSegmentNodes().get(0),2, 5, 7.5);
+		List<VectorXZ> thirdEndPointsList = thirdWall.getNewEndPoints(thirdWall.getWallSegmentNodes().get(0),3, 7.5, 10);
+
+		assertEquals(0, endPointsList.get(3).subtract(secondEndPointsList.get(0)).length(), 0.05);
+		assertEquals(0, endPointsList.get(2).subtract(secondEndPointsList.get(1)).length(), 0.05);
+
+		assertEquals(thirdStartNodePos.add(thirdRightNormal.mult(-thirdWall.getWallThickness())), thirdEndPointsList.get(0));
+		assertEquals(thirdStartNodePos.add(thirdRightNormal.mult(thirdWall.getWallThickness())), thirdEndPointsList.get(1));
+		assertEquals(thirdEndNodePos.add(thirdRightNormal.mult(thirdWall.getWallThickness())), thirdEndPointsList.get(2));
+		assertEquals(thirdEndNodePos.add(thirdRightNormal.mult(-thirdWall.getWallThickness())), thirdEndPointsList.get(3));
+
+	}
+
+}


### PR DESCRIPTION
**Walls**

Walls have been split less aggressively to allow for placement of windows and doors, shaped to some roof types, given thickness and walls on the outer edge of buildings are moved indoors.

*Known Issues*

- Polygons used to fill gaps at wall junctions do not always work.
- Junctions where only part of one wall is an outer wall have gaps due to the offset.

![OSMOffsetJunction](https://user-images.githubusercontent.com/31134699/89740448-a5c45d00-da80-11ea-962f-10b6f4624346.png)

- Wall tops and ceilings  do not conform to the roof shape

**Windows and Doors**

Windows and doors are placed within walls. Windows use the  GLASS_TRANSPARENT material if there are indoor area elements on both sides or are on an outer wall with and indoor area element on the inside.

*Known Issues*

- Outer windows do not follow "min_level", "max_level" and "non_existent_levels" tags