### PR TITLE
Remove redundant dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,47 @@
 			<groupId>de.topobyte</groupId>
 			<artifactId>osm4j-core</artifactId>
 			<version>0.1.0</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-object-procedure</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-object-function</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-long-function</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-long-procedure</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-iterator</artifactId>
+				</exclusion>
+		   	</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>de.topobyte</groupId>
 			<artifactId>osm4j-pbf</artifactId>
 			<version>0.1.1</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-object-int-map</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-object-procedure</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.slimjars.trove4j</groupId>
+				    <artifactId>trove4j-advancing-iterator</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>de.topobyte</groupId>
@@ -156,12 +192,20 @@
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-transcoder</artifactId>
 			<version>1.11</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-rasterizer</artifactId>
-			<version>1.11</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>org.apache.xmlgraphics</groupId>
+				    <artifactId>batik-ext</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>xml-apis</groupId>
+				    <artifactId>xml-apis</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.xmlgraphics</groupId>
+				    <artifactId>batik-constants</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Hi, I am a user of project **_org.osm2world:osm2world:0.3.0-SNAPSHOT_**. I found that its pom file introduced **_124_** dependencies. However, among them, **_17_** libraries (**_13%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. Finally, it can help enable advanced scenarios for users of your package. 
This PR helps **_org.osm2world:osm2world:0.3.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.apache.xmlgraphics:batik-constants:jar:1.11:compile
com.slimjars.trove4j:trove4j-object-procedure:jar:1.0.1:compile
org.apache.xmlgraphics:batik-svgrasterizer:jar:1.11:compile
com.slimjars.trove4j:trove4j-int-collection:jar:1.0.1:compile
xml-apis:xml-apis:jar:1.3.04:compile
org.apache.xmlgraphics:batik-codec:jar:1.11:compile
org.apache.xmlgraphics:batik-rasterizer:jar:1.11:compile
com.slimjars.trove4j:trove4j-object-int-procedure:jar:1.0.1:compile
com.slimjars.trove4j:trove4j-int-function:jar:1.0.1:compile
com.slimjars.trove4j:trove4j-long-procedure:jar:1.0.1:compile
com.slimjars.trove4j:trove4j-object-function:jar:1.0.1:compile
com.slimjars.trove4j:trove4j-object-int-iterator:jar:1.0.1:compile
org.apache.xmlgraphics:batik-ext:jar:1.11:compile
com.slimjars.trove4j:trove4j-int-iterator:jar:1.0.1:compile
com.slimjars.trove4j:trove4j-long-function:jar:1.0.1:compile
com.slimjars.trove4j:trove4j-int-procedure:jar:1.0.1:compile
com.slimjars.trove4j:trove4j-object-int-map:jar:1.0.1:compile
</code></pre>