### PR TITLE
Road elevation smoothing based on heat equation(Diffusion Equation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin
+test_diffusion.sh
 build
 .
 ..

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ doc/javadoc
 /dist/
 /textures
 /target/
+*.DS_Store
+/.settings

--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,34 @@
+#blender script
+import bpy
+import csv
+import os, sys
+
+filepath = bpy.data.filepath
+directory = os.path.dirname(filepath)
+reader = csv.reader(open(os.path.join(directory,"roadpoints.csv")),quoting=csv.QUOTE_NONNUMERIC)
+count=0
+# make mesh
+vertices = []
+edges = []
+faces = []
+for row in reader:
+	z=5
+	if count%3==0:
+		z=10;
+	if count%3==2:
+		faces.append([count-2,count-1,count])
+	print(len(row))
+	print(count)
+	vertices.append((row[0],row[2],row[1]))
+	count=count+1
+
+new_mesh = bpy.data.meshes.new('new_mesh')
+new_mesh.from_pydata(vertices, edges, faces)
+new_mesh.update()
+# make object from mesh
+new_object = bpy.data.objects.new('new_object', new_mesh)
+# make collection
+new_collection = bpy.data.collections.new('new_collection')
+bpy.context.scene.collection.children.link(new_collection)
+# add object to scene collection
+new_collection.objects.link(new_object)

--- a/src/main/java/org/osm2world/console/Output.java
+++ b/src/main/java/org/osm2world/console/Output.java
@@ -25,6 +25,7 @@ import org.osm2world.core.map_elevation.creation.LeastSquaresInterpolator;
 import org.osm2world.core.map_elevation.creation.NaturalNeighborInterpolator;
 import org.osm2world.core.map_elevation.creation.NoneEleConstraintEnforcer;
 import org.osm2world.core.map_elevation.creation.SimpleEleConstraintEnforcer;
+import org.osm2world.core.map_elevation.creation.SimpleInterpolatedEleConstraintEnforcer;
 import org.osm2world.core.map_elevation.creation.ZeroInterpolator;
 import org.osm2world.core.math.AxisAlignedRectangleXZ;
 import org.osm2world.core.math.VectorXYZ;
@@ -120,6 +121,8 @@ public final class Output {
 			cf.setEleConstraintEnforcerFactory(SimpleEleConstraintEnforcer::new);
 		}else if ("DiffusionEleConstraintEnforcer".equals(enforcerType)) {
 			cf.setEleConstraintEnforcerFactory(DiffusionEleConstraintEnforcer::new);
+		}else if ("SimpleInterpolatedEleConstraintEnforcer".equals(enforcerType)) {
+			cf.setEleConstraintEnforcerFactory(SimpleInterpolatedEleConstraintEnforcer::new);
 		}
 
 		Results results = cf.createRepresentations(dataReader.getData(), null, config, null);

--- a/src/main/java/org/osm2world/console/Output.java
+++ b/src/main/java/org/osm2world/console/Output.java
@@ -20,6 +20,7 @@ import org.osm2world.core.ConversionFacade.ProgressListener;
 import org.osm2world.core.ConversionFacade.Results;
 import org.osm2world.core.map_data.creation.LatLon;
 import org.osm2world.core.map_data.creation.MapProjection;
+import org.osm2world.core.map_elevation.creation.DiffusionEleConstraintEnforcer;
 import org.osm2world.core.map_elevation.creation.LeastSquaresInterpolator;
 import org.osm2world.core.map_elevation.creation.NaturalNeighborInterpolator;
 import org.osm2world.core.map_elevation.creation.NoneEleConstraintEnforcer;
@@ -118,7 +119,7 @@ public final class Output {
 		} else if ("SimpleEleConstraintEnforcer".equals(enforcerType)) {
 			cf.setEleConstraintEnforcerFactory(SimpleEleConstraintEnforcer::new);
 		}else if ("DiffusionEleConstraintEnforcer".equals(enforcerType)) {
-			cf.setEleConstraintEnforcerFactory(SimpleEleConstraintEnforcer::new);
+			cf.setEleConstraintEnforcerFactory(DiffusionEleConstraintEnforcer::new);
 		}
 
 		Results results = cf.createRepresentations(dataReader.getData(), null, config, null);

--- a/src/main/java/org/osm2world/console/Output.java
+++ b/src/main/java/org/osm2world/console/Output.java
@@ -117,6 +117,8 @@ public final class Output {
 			cf.setEleConstraintEnforcerFactory(NoneEleConstraintEnforcer::new);
 		} else if ("SimpleEleConstraintEnforcer".equals(enforcerType)) {
 			cf.setEleConstraintEnforcerFactory(SimpleEleConstraintEnforcer::new);
+		}else if ("DiffusionEleConstraintEnforcer".equals(enforcerType)) {
+			cf.setEleConstraintEnforcerFactory(SimpleEleConstraintEnforcer::new);
 		}
 
 		Results results = cf.createRepresentations(dataReader.getData(), null, config, null);

--- a/src/main/java/org/osm2world/core/ConversionFacade.java
+++ b/src/main/java/org/osm2world/core/ConversionFacade.java
@@ -23,6 +23,7 @@ import org.osm2world.core.map_data.creation.MetricMapProjection;
 import org.osm2world.core.map_data.creation.OSMToMapDataConverter;
 import org.osm2world.core.map_data.creation.OriginMapProjection;
 import org.osm2world.core.map_data.data.MapData;
+import org.osm2world.core.map_elevation.creation.DiffusionEleConstraintEnforcer;
 import org.osm2world.core.map_elevation.creation.EleConstraintEnforcer;
 import org.osm2world.core.map_elevation.creation.EleConstraintValidator;
 import org.osm2world.core.map_elevation.creation.NoneEleConstraintEnforcer;
@@ -77,8 +78,8 @@ import de.topobyte.osm4j.core.model.iface.OsmBounds;
 import de.topobyte.osm4j.core.resolve.EntityNotFoundException;
 
 /**
- * provides an easy way to call all steps of the conversion process
- * in the correct order
+ * provides an easy way to call all steps of the conversion process in the
+ * correct order
  */
 public class ConversionFacade {
 
@@ -116,30 +117,12 @@ public class ConversionFacade {
 	 */
 	private static final List<WorldModule> createDefaultModuleList() {
 
-		return Arrays.asList((WorldModule)
-				new RoadModule(),
-				new RailwayModule(),
-				new AerowayModule(),
-				new BuildingModule(),
-				new ParkingModule(),
-				new TreeModule(),
-				new StreetFurnitureModule(),
-				new TrafficSignModule(),
-				new BicycleParkingModule(),
-				new WaterModule(),
-				new PoolModule(),
-				new GolfModule(),
-				new SportsModule(),
-				new CliffModule(),
-				new BarrierModule(),
-				new PowerModule(),
-				new MastModule(),
-				new BridgeModule(),
-				new TunnelModule(),
-				new SurfaceAreaModule(),
-				new InvisibleModule(),
-				new IndoorModule()
-		);
+		return Arrays.asList((WorldModule) new RoadModule(), new RailwayModule(), new AerowayModule(),
+				new BuildingModule(), new ParkingModule(), new TreeModule(), new StreetFurnitureModule(),
+				new TrafficSignModule(), new BicycleParkingModule(), new WaterModule(), new PoolModule(),
+				new GolfModule(), new SportsModule(), new CliffModule(), new BarrierModule(), new PowerModule(),
+				new MastModule(), new BridgeModule(), new TunnelModule(), new SurfaceAreaModule(),
+				new InvisibleModule(), new IndoorModule());
 
 	}
 
@@ -150,53 +133,46 @@ public class ConversionFacade {
 	private Factory<? extends EleConstraintEnforcer> eleConstraintEnforcerFactory = NoneEleConstraintEnforcer::new;
 
 	/**
-	 * sets the factory that will make {@link MapProjection}
-	 * instances during subsequent calls to
+	 * sets the factory that will make {@link MapProjection} instances during
+	 * subsequent calls to
 	 * {@link #createRepresentations(OSMData, List, Configuration, List)}.
 	 */
-	public void setMapProjectionFactory(
-			Factory<? extends OriginMapProjection> mapProjectionFactory) {
+	public void setMapProjectionFactory(Factory<? extends OriginMapProjection> mapProjectionFactory) {
 		this.mapProjectionFactory = mapProjectionFactory;
 	}
 
 	/**
-	 * sets the factory that will make {@link EleConstraintEnforcer}
-	 * instances during subsequent calls to
+	 * sets the factory that will make {@link EleConstraintEnforcer} instances
+	 * during subsequent calls to
 	 * {@link #createRepresentations(OSMData, List, Configuration, List)}.
 	 */
-	public void setEleConstraintEnforcerFactory(
-			Factory<? extends EleConstraintEnforcer> interpolatorFactory) {
+	public void setEleConstraintEnforcerFactory(Factory<? extends EleConstraintEnforcer> interpolatorFactory) {
 		this.eleConstraintEnforcerFactory = interpolatorFactory;
 	}
 
 	/**
-	 * sets the factory that will make {@link TerrainInterpolator}
-	 * instances during subsequent calls to
+	 * sets the factory that will make {@link TerrainInterpolator} instances during
+	 * subsequent calls to
 	 * {@link #createRepresentations(OSMData, List, Configuration, List)}.
 	 */
-	public void setTerrainEleInterpolatorFactory(
-			Factory<? extends TerrainInterpolator> enforcerFactory) {
+	public void setTerrainEleInterpolatorFactory(Factory<? extends TerrainInterpolator> enforcerFactory) {
 		this.terrainEleInterpolatorFactory = enforcerFactory;
 	}
 
-
 	/**
-	 * performs all necessary steps to go from
-	 * an OSM file to the renderable {@link WorldObject}s.
-	 * Sends updates to {@link ProgressListener}s.
+	 * performs all necessary steps to go from an OSM file to the renderable
+	 * {@link WorldObject}s. Sends updates to {@link ProgressListener}s.
 	 *
-	 * @param osmFile       file to read OSM data from; != null
-	 * @param worldModules  modules that will create the {@link WorldObject}s
-	 *                      in the result; null to use a default module list
-	 * @param config        set of parameters that controls various aspects
-	 *                      of the modules' behavior; null to use defaults
-	 * @param targets       receivers of the conversion results; can be null if
-	 *                      you want to handle the returned results yourself
+	 * @param osmFile      file to read OSM data from; != null
+	 * @param worldModules modules that will create the {@link WorldObject}s in the
+	 *                     result; null to use a default module list
+	 * @param config       set of parameters that controls various aspects of the
+	 *                     modules' behavior; null to use defaults
+	 * @param targets      receivers of the conversion results; can be null if you
+	 *                     want to handle the returned results yourself
 	 */
-	public Results createRepresentations(File osmFile,
-			List<? extends WorldModule> worldModules, Configuration config,
-			List<? extends Target> targets)
-			throws IOException {
+	public Results createRepresentations(File osmFile, List<? extends WorldModule> worldModules, Configuration config,
+			List<? extends Target> targets) throws IOException {
 
 		if (osmFile == null) {
 			throw new IllegalArgumentException("osmFile must not be null");
@@ -209,27 +185,23 @@ public class ConversionFacade {
 	}
 
 	/**
-	 * variant of
-	 * {@link #createRepresentations(File, List, Configuration, List)}
-	 * that accepts {@link OSMData} instead of a file.
-	 * Use this when all data is already
-	 * in memory, for example with editor applications.
-	 * To obtain the data, you can use an {@link OSMDataReader}.
+	 * variant of {@link #createRepresentations(File, List, Configuration, List)}
+	 * that accepts {@link OSMData} instead of a file. Use this when all data is
+	 * already in memory, for example with editor applications. To obtain the data,
+	 * you can use an {@link OSMDataReader}.
 	 *
-	 * @param osmData       input data; != null
-	 * @param worldModules  modules that will create the {@link WorldObject}s
-	 *                      in the result; null to use a default module list
-	 * @param config        set of parameters that controls various aspects
-	 *                      of the modules' behavior; null to use defaults
-	 * @param targets       receivers of the conversion results; can be null if
-	 *                      you want to handle the returned results yourself
+	 * @param osmData      input data; != null
+	 * @param worldModules modules that will create the {@link WorldObject}s in the
+	 *                     result; null to use a default module list
+	 * @param config       set of parameters that controls various aspects of the
+	 *                     modules' behavior; null to use defaults
+	 * @param targets      receivers of the conversion results; can be null if you
+	 *                     want to handle the returned results yourself
 	 *
-	 * @throws BoundingBoxSizeException  for oversized bounding boxes
+	 * @throws BoundingBoxSizeException for oversized bounding boxes
 	 */
-	public Results createRepresentations(OSMData osmData,
-			List<? extends WorldModule> worldModules, Configuration config,
-			List<? extends Target> targets)
-			throws IOException, BoundingBoxSizeException {
+	public Results createRepresentations(OSMData osmData, List<? extends WorldModule> worldModules,
+			Configuration config, List<? extends Target> targets) throws IOException, BoundingBoxSizeException {
 
 		/* check the inputs */
 
@@ -273,11 +245,10 @@ public class ConversionFacade {
 		}
 
 		Materials.configureMaterials(config);
-			//this will cause problems if multiple conversions are run
-			//at the same time, because global variables are being modified
+		// this will cause problems if multiple conversions are run
+		// at the same time, because global variables are being modified
 
-		WorldCreator moduleManager =
-			new WorldCreator(config, worldModules);
+		WorldCreator moduleManager = new WorldCreator(config, worldModules);
 		moduleManager.addRepresentationsTo(mapData);
 
 		/* determine elevations */
@@ -316,11 +287,12 @@ public class ConversionFacade {
 
 		/* collect the surfaces */
 
-		SpatialIndex<AttachmentSurface> attachmentSurfaceIndex =
-				new IndexGrid<>(mapData.getDataBoundary().pad(50), 100, 100);
+		SpatialIndex<AttachmentSurface> attachmentSurfaceIndex = new IndexGrid<>(mapData.getDataBoundary().pad(50), 100,
+				100);
 
 		for (WorldObject object : mapData.getWorldObjects()) {
-			if (object.getParent() != null) continue;
+			if (object.getParent() != null)
+				continue;
 			object.getAttachmentSurfaces().forEach(attachmentSurfaceIndex::insert);
 		}
 
@@ -328,12 +300,13 @@ public class ConversionFacade {
 
 		for (WorldObject object : mapData.getWorldObjects()) {
 
-			if (object.getParent() != null) continue;
+			if (object.getParent() != null)
+				continue;
 
 			for (AttachmentConnector connector : object.getAttachmentConnectors()) {
 
-				Iterable<AttachmentSurface> nearbySurfaces = attachmentSurfaceIndex.probe(
-						bbox(singleton(connector.originalPos)).pad(connector.maxDistanceXZ));
+				Iterable<AttachmentSurface> nearbySurfaces = attachmentSurfaceIndex
+						.probe(bbox(singleton(connector.originalPos)).pad(connector.maxDistanceXZ));
 
 				Optional<AttachmentSurface> closestSurface = Streams.stream(nearbySurfaces)
 						.filter(s -> s.getTypes().stream().anyMatch(connector.compatibleSurfaceTypes::contains))
@@ -341,7 +314,8 @@ public class ConversionFacade {
 
 				if (closestSurface.isPresent()) {
 
-					double ele = closestSurface.get().getBaseEleAt(connector.originalPos.xz()) + connector.preferredHeight;
+					double ele = closestSurface.get().getBaseEleAt(connector.originalPos.xz())
+							+ connector.preferredHeight;
 					VectorXYZ posAtEle = connector.originalPos.y(ele);
 
 					for (boolean requirePreferredHeight : asList(true, false)) {
@@ -357,14 +331,15 @@ public class ConversionFacade {
 						};
 
 						Optional<FaceXYZ> closestFace = closestSurface.get().getFaces().stream()
-								.filter(matchesPreferredHeight)
-								.min(comparingDouble(f -> f.distanceTo(posAtEle)));
+								.filter(matchesPreferredHeight).min(comparingDouble(f -> f.distanceTo(posAtEle)));
 
-						if (!closestFace.isPresent()) continue; // try again without enforcing the preferred height
+						if (!closestFace.isPresent())
+							continue; // try again without enforcing the preferred height
 
 						VectorXYZ closestPoint = closestFace.get().closestPoint(posAtEle);
 
-						if (closestPoint.xz().distanceTo(connector.originalPos.xz()) > connector.maxDistanceXZ + 0.001) {
+						if (closestPoint.xz().distanceTo(connector.originalPos.xz()) > connector.maxDistanceXZ
+								+ 0.001) {
 							continue;
 						}
 
@@ -382,16 +357,13 @@ public class ConversionFacade {
 	}
 
 	/**
-	 * uses OSM data and an terrain elevation data (usually from an external
-	 * source) to calculate elevations for all {@link EleConnector}s of the
+	 * uses OSM data and an terrain elevation data (usually from an external source)
+	 * to calculate elevations for all {@link EleConnector}s of the
 	 * {@link WorldObject}s
 	 */
-	private void calculateElevations(MapData mapData,
-			TerrainElevationData eleData, Configuration config) {
+	private void calculateElevations(MapData mapData, TerrainElevationData eleData, Configuration config) {
 
-		final TerrainInterpolator interpolator =
-				(eleData != null)
-				? terrainEleInterpolatorFactory.get()
+		final TerrainInterpolator interpolator = (eleData != null) ? terrainEleInterpolatorFactory.get()
 				: new ZeroInterpolator();
 
 		/* provide known elevations from eleData to the interpolator */
@@ -437,28 +409,46 @@ public class ConversionFacade {
 		});
 
 		System.out.println("time terrain interpolation: " + stopWatch);
+		System.out.flush();
+
 		stopWatch.reset();
 		stopWatch.start();
 
 		/* enforce constraints defined by WorldObjects */
 
+		System.out.println("enforcer.addConnectors");
+		System.out.flush();
+
 		boolean debugConstraints = config.getBoolean("debugConstraints", false);
 
 		final EleConstraintEnforcer enforcer = debugConstraints
-				? new EleConstraintValidator(mapData,
-						eleConstraintEnforcerFactory.get())
+				? new EleConstraintValidator(mapData, eleConstraintEnforcerFactory.get())
 				: eleConstraintEnforcerFactory.get();
 
 		enforcer.addConnectors(connectors);
 
 		if (!(enforcer instanceof NoneEleConstraintEnforcer)) {
 
-			FaultTolerantIterationUtil.forEach(mapData.getWorldObjects(),
-					(WorldObject o) -> o.defineEleConstraints(enforcer));
-
+			System.out.println("defineEleConstraints");
+			System.out.flush();
+			long startTime = System.currentTimeMillis();
+			long lastTime = startTime;
+			long count = 0;
+			for (WorldObject o : mapData.getWorldObjects()) {
+				o.defineEleConstraints(enforcer);
+				count++;
+				long current = System.currentTimeMillis();
+				if (current - lastTime > 1000) {
+					System.out.println(
+							"creating graph:" + (count) + "/" + connectors.size() + " " + (current - startTime) + "ms");
+					lastTime = current;
+				}
+			}
 		}
 
 		System.out.println("time add constraints: " + stopWatch);
+		System.out.flush();
+
 		stopWatch.reset();
 		stopWatch.start();
 
@@ -471,24 +461,20 @@ public class ConversionFacade {
 	}
 
 	public static enum Phase {
-		MAP_DATA,
-		REPRESENTATION,
-		ELEVATION,
-		TERRAIN,
-		FINISHED
+		MAP_DATA, REPRESENTATION, ELEVATION, TERRAIN, FINISHED
 	}
 
 	/**
-	 * implemented by classes that want to be informed about
-	 * a conversion run's progress
+	 * implemented by classes that want to be informed about a conversion run's
+	 * progress
 	 */
 	public static interface ProgressListener {
 
 		/** announces the start of a new phase */
 		public void updatePhase(Phase newPhase);
 
-//		/** announces the fraction of the current phase that is completed */
-//		public void updatePhaseProgress(float phaseProgress);
+		// /** announces the fraction of the current phase that is completed */
+		// public void updatePhaseProgress(float phaseProgress);
 
 	}
 
@@ -504,19 +490,19 @@ public class ConversionFacade {
 		}
 	}
 
-//	private void updatePhaseProgress(float phaseProgress) {
-//		for (ProgressListener listener : listeners) {
-//			listener.updatePhaseProgress(phaseProgress);
-//		}
-//	}
+	// private void updatePhaseProgress(float phaseProgress) {
+	// for (ProgressListener listener : listeners) {
+	// listener.updatePhaseProgress(phaseProgress);
+	// }
+	// }
 
 	/**
-	 * exception to be thrown if the OSM input data covers an area
-	 * larger than the maxBoundingBoxDegrees config property
+	 * exception to be thrown if the OSM input data covers an area larger than the
+	 * maxBoundingBoxDegrees config property
 	 */
 	public static class BoundingBoxSizeException extends RuntimeException {
 
-		private static final long serialVersionUID = 2841146365929523046L; //generated VersionID
+		private static final long serialVersionUID = 2841146365929523046L; // generated VersionID
 		public final OsmBounds bound;
 
 		private BoundingBoxSizeException(OsmBounds bound) {

--- a/src/main/java/org/osm2world/core/ConversionFacade.java
+++ b/src/main/java/org/osm2world/core/ConversionFacade.java
@@ -425,6 +425,7 @@ public class ConversionFacade {
 				? new EleConstraintValidator(mapData, eleConstraintEnforcerFactory.get())
 				: eleConstraintEnforcerFactory.get();
 
+		System.out.println("calculateElevations:connectors.size()" + connectors.size());
 		enforcer.addConnectors(connectors);
 
 		if (!(enforcer instanceof NoneEleConstraintEnforcer)) {

--- a/src/main/java/org/osm2world/core/ConversionFacade.java
+++ b/src/main/java/org/osm2world/core/ConversionFacade.java
@@ -436,12 +436,16 @@ public class ConversionFacade {
 			long lastTime = startTime;
 			long count = 0;
 			for (WorldObject o : mapData.getWorldObjects()) {
-				o.defineEleConstraints(enforcer);
+				try {
+					o.defineEleConstraints(enforcer);
+				} catch (Exception e) {
+
+				}
 				count++;
 				long current = System.currentTimeMillis();
-				if (current - lastTime > 1000) {
+				if (current - lastTime > 5000) {
 					System.out.println(
-							"creating graph:" + (count) + "/" + connectors.size() + " " + (current - startTime) + "ms");
+							"defineEleConstraints:" + (count) + "/" + connectors.size() + " " + (current - startTime) + "ms");
 					lastTime = current;
 				}
 			}

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -22,7 +22,6 @@ import org.osm2world.core.map_data.data.MapWaySegment;
 import org.osm2world.core.map_elevation.data.EleConnector;
 import org.osm2world.core.map_elevation.data.GroundState;
 import org.osm2world.core.math.VectorXYZ;
-import org.osm2world.core.target.common.material.Material.Interpolation;
 import org.osm2world.core.world.data.NodeWorldObject;
 import org.osm2world.core.world.modules.BridgeModule;
 import org.osm2world.core.world.modules.RoadModule;
@@ -351,54 +350,12 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		if (from.size() == 0) {
 			return;
 		}
-
-		List<Double> hs = new ArrayList<Double>();
-		List<Double> xs = new ArrayList<Double>();
-		{
-			double l = 0;
-			VectorXYZ before = from.get(0).getPosXYZ();
-			for (int i = 0; i < from.size(); i++) {
-				VectorXYZ pos = from.get(i).getPosXYZ();
-				l += pos.distanceToXZ(before);
-
-				hs.add(heightMap.get(from.get(i)));
-				xs.add(l);
-				before = pos;
-			}
-		}
-		double total = 0;
-		{
-			VectorXYZ before = to.get(0).getPosXYZ();
-			for (int i = 0; i < from.size(); i++) {
-				VectorXYZ pos = from.get(i).getPosXYZ();
-				total += pos.distanceToXZ(before);
-			}
-		}
-		{
-			double l = 0;
-			VectorXYZ before = to.get(0).getPosXYZ();
-			for (EleConnector target : to) {
-				VectorXYZ pos = target.getPosXYZ();
-				l += pos.distanceToXZ(before);
-				boolean found = false;
-				heightMap.put(target, hs.get(0));
-				for (int i = 1; i < from.size(); i++) {
-					double x = l / total;
-					double x1 = xs.get(i) / xs.get(xs.size() - 1);
-					double h1 = hs.get(i);
-					double x2 = xs.get(i - 1) / xs.get(xs.size() - 1);
-					double h2 = hs.get(i - 1);
-					if (x1 >= x) {
-						found = true;
-						heightMap.put(target, (h1 * (x - x2) + h2 * (x1 - x)) / (x1 - x2));
-						break;
-					}
-				}
-				if(!found){
-					heightMap.put(target, hs.get(hs.size()-1));
-				}
-
-			}
+		
+		double conversionratio = (double) from.size() / to.size();
+		for (int i = 0; i < to.size(); i++) {
+			int i_from = (int) Math.round((double) (i * conversionratio));
+			i_from = i_from >= from.size() ? from.size() : i_from;
+			heightMap.put(to.get(i), heightMap.get(from.get(i_from)));
 		}
 	}
 

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -41,26 +41,8 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 	int connectedCount = 0;
 
 	private Map<EleConnector, List<EleConnector>> roadConnectedTo = new HashMap<EleConnector, List<EleConnector>>();
-	private Map<EleConnector, Double> heightMap = new HashMap<EleConnector, Double>();
 
-	private void addConnection(EleConnector from, EleConnector to) {
-		EleConnector a = from;
-		EleConnector b = to;
-		if (a == b) {
-			return;
-		}
-		for (int i = 0; i < 2; i++) {
-			roadConnectedTo.putIfAbsent(a, new ArrayList<EleConnector>());
-			List<EleConnector> connectors = roadConnectedTo.get(a);
-			if (!connectors.contains(b)) {
-				connectors.add(b);
-			}
-			// swap a and b
-			EleConnector temp = a;
-			a = b;
-			b = temp;
-		}
-	}
+	private Map<MapNode, EleConnector> mapNodeToEleconnector = new HashMap<MapNode, EleConnector>();
 
 	@Override
 	public void addConnectors(Iterable<EleConnector> newConnectors) {
@@ -198,19 +180,39 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			}
 
 		}
-		for (EleConnector c : connectors) {
-			// TODO use clearing
+		connectors.forEach((c) -> {
 			if (c.reference != null) {
-				System.out.println(c.reference.getClass().getName());
 				if (c.reference instanceof MapNode) {
 					MapNode mn = (MapNode) c.reference;
-					List<Road> roads=RoadModule.getConnectedRoads(mn,true);
-					roads.forEach((road)->{
-						System.out.println(road);
+					mapNodeToEleconnector.put(mn, c);
+				}
+			}
+		});
+		connectors.forEach((c) -> {
+			if (c.reference != null) {
+				if (c.reference instanceof MapNode) {
+					MapNode mn = (MapNode) c.reference;
+					List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+					roads.forEach((road) -> {
+						//System.out.println(road);
+						road.getPrimaryMapElement().getEndNode();
+						road.getPrimaryMapElement().getStartNode();
 					});
 				}
-
 			}
+		});
+		for (EleConnector c : connectors) {
+			// TODO use clearing
+			/*
+			 * if (c.reference != null) {
+			 * System.out.println(c.reference.getClass().getName()); if (c.reference
+			 * instanceof MapNode) { MapNode mn = (MapNode) c.reference;
+			 * mapNodeToEleconnector.put(mn, c); List<Road> roads =
+			 * RoadModule.getConnectedRoads(mn, false);// requirelanes? roads.forEach((road)
+			 * -> { System.out.println(road); }); c.setPosXYZ(c.getPosXYZ().addY(30)); }
+			 * 
+			 * }
+			 */
 			switch (c.groundState) {
 				case ABOVE:
 					c.setPosXYZ(c.getPosXYZ().addY(5));
@@ -222,7 +224,6 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 					break;
 				default: // stay at ground elevation
 			}
-			heightMap.put(c, c.getPosXYZ().y);
 		}
 	}
 

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -208,21 +208,7 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		Map<EleConnector, Double> heightMap1 = new HashMap<EleConnector, Double>();
 
 		// initialize height map
-		// for (EleConnector c : connectors) {
-		// double h = 0;
-		// switch (c.groundState) {
-		// case ABOVE:
-		// h = 5.0;
-		// break;
-		// case BELOW:
-		// h = -5.0;
-		// break;
-		// default: // stay at ground elevation
-		// }
-		// heightMap.put(c, h);
-		// heightMap1.put(c, h);
-		// }
-		// connectors.forEach((c) -> {
+		
 		for (EleConnector c : connectors) {
 			if (c.reference != null) {
 				if (c.reference instanceof MapNode) {
@@ -230,7 +216,7 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 					mapNodeToEleconnector.put(mn, c);
 				}
 			} else {
-				System.out.println(c);
+				// System.out.println(c);
 			}
 		}
 
@@ -254,34 +240,6 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			}
 		}
 		for (EleConnector c : connectors) {
-			if (c.reference instanceof MapNode) {
-				MapNode mn = (MapNode) c.reference;
-				List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
-				roads.forEach((road) -> {
-					MapNode start = road.getPrimaryMapElement().getStartNode();
-					MapNode end = road.getPrimaryMapElement().getEndNode();
-					EleConnector a = mapNodeToEleconnector.get(start);
-					EleConnector b = mapNodeToEleconnector.get(end);
-					try {
-						List<EleConnector> center = road.getCenterlineEleConnectors();
-						interpolateConnection(center, a, b, false);
-					} catch (Exception e) {
-						System.out.println("center" + e.getStackTrace());
-					}
-					try {
-						List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
-						interpolateConnection(left, a, b, true);
-					} catch (Exception e) {
-					}
-					try {
-						List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
-						interpolateConnection(right, a, b, true);
-					} catch (Exception e) {
-					}
-				});
-			}
-		}
-		for (EleConnector c : connectors) {
 			double h = 0;
 			switch (c.groundState) {
 				case ABOVE:
@@ -295,11 +253,11 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			heightMap.put(c, h);
 			heightMap1.put(c, h);
 		}
-		double dt = 0.01;
-		double conductance = 100;
-		for (double t = 0; t < 1; t++) {
+		double dt = 0.1;
+		double conductance = 1;
+		for (double t = 0; t < 3; t += dt) {
 			for (EleConnector c : connectors) {
-				double h = 0;
+				double h = heightMap.get(c);
 				switch (c.groundState) {
 					case ABOVE:
 						h = 5.0;
@@ -309,26 +267,15 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 						break;
 					default: // stay at ground elevation
 				}
-				// heightMap.put(c, h);
-				// heightMap1.put(c, h);
-			}
-			for (EleConnector c : roadGraph.keySet()) {
-				for (RoadNetworkEdge edge : roadGraph.get(c)) {
-					if (edge.distance <= 0.1) {
-						double average = heightMap.get(edge.b) + heightMap.get(edge.a);
-						average *= 0.5;
-						heightMap.put(edge.a, average);
-						heightMap.put(edge.b, average);
-					}
-				}
+				heightMap.put(c, h);
+				heightMap1.put(c, h);
 			}
 			for (EleConnector a : roadGraph.keySet()) {
 				double dhdt = 0;
 				double h = heightMap.get(a);
 				for (RoadNetworkEdge edge : roadGraph.get(a)) {
-					if (edge.distance > 0.1) {
-						dhdt -= conductance / edge.distance * (h - heightMap.get(edge.b));
-					}
+					dhdt -= conductance * Math.min(1, 1.0 / edge.distance) * (h - heightMap.get(edge.b));
+					// System.out.println(edge.distance);
 				}
 				heightMap1.put(a, dhdt * dt + h);
 			}
@@ -338,24 +285,77 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		}
 
 		for (EleConnector c : connectors) {
+			if (c.reference instanceof MapNode) {
+				MapNode mn = (MapNode) c.reference;
+				List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+				roads.forEach((road) -> {
+					MapNode start = road.getPrimaryMapElement().getStartNode();
+					MapNode end = road.getPrimaryMapElement().getEndNode();
+					EleConnector a = mapNodeToEleconnector.get(start);
+					EleConnector b = mapNodeToEleconnector.get(end);
+					try {
+						List<EleConnector> center = road.getCenterlineEleConnectors();
+						interpolateConnection(heightMap,center, a, b, false);
+					} catch (Exception e) {
+						// System.out.println("center" + e.getStackTrace());
+					}
+					try {
+						List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
+						interpolateConnection(heightMap,left, a, b, true);
+					} catch (Exception e) {
+					}
+					try {
+						List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
+						interpolateConnection(heightMap,right, a, b, true);
+					} catch (Exception e) {
+					}
+				});
+			}
+		}
+		for (EleConnector c : connectors) {
 			double h = heightMap.get(c);
 			c.setPosXYZ(c.getPosXYZ().addY(h));
 		}
+	}
 
-		if (true) {
+	private void interpolateConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center,
+			EleConnector start, EleConnector end, boolean isSide) {
+		if (center.size() == 0) {
 			return;
 		}
-
-		// // });
-
-		// roadList.forEach((c) -> {
-		for (EleConnector c : roadList) {
-			VectorXYZ xyz = c.getPosXYZ();
-			// c.setPosXYZ(new VectorXYZ(xyz.x, heightMap.get(c), xyz.z));
-			c.setPosXYZ(xyz.addY(heightMap.get(c)));
+		// calculate length of road
+		// length will be used to calculate weights for linear interpolation
+		double length = 0;
+		if (isSide) {
+			EleConnector before = center.get(0);
+			for (int i = 0; i < center.size(); i++) {
+				EleConnector segment = center.get(i);
+				length += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
+				before = segment;
+			}
+		} else {
+			EleConnector before = start;
+			for (int i = 0; i < center.size(); i++) {
+				EleConnector segment = center.get(i);
+				length += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
+				before = segment;
+			}
+			length += end.getPosXYZ().distanceToXZ(before.getPosXYZ());
 		}
-		// });
-		return;
+		// System.out.println("length=" + length);
+
+		{
+			double pos = 0;
+			double startHeight = heightMap.get(start);
+			double endHeight = heightMap.get(end);
+			EleConnector before = isSide ? center.get(0) : start;
+			for (int i = 0; i < center.size(); i++) {
+				EleConnector segment = center.get(i);
+				pos += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
+				heightMap.put(segment, endHeight * pos / length + startHeight * (1 - pos / length));
+				before = segment;
+			}
+		}
 	}
 
 	// add connection to node edges
@@ -369,7 +369,8 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		for (int i = 0; i < 2; i++) {
 			if (roadGraph.containsKey(a)) {
 				boolean found = false;
-				for (RoadNetworkEdge edge : roadGraph.get(a)) {
+				List<RoadNetworkEdge> edges = roadGraph.get(a);
+				for (RoadNetworkEdge edge : edges) {
 					if (edge.a == a && edge.b == b) {
 						found = true;
 						break;
@@ -380,7 +381,6 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 					}
 				}
 				if (!found) {
-					List<RoadNetworkEdge> edges = new ArrayList<RoadNetworkEdge>();
 					edges.add(new RoadNetworkEdge(a, b, distance));
 					roadGraph.put(a, edges);
 				}
@@ -392,41 +392,6 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			EleConnector temp = a;
 			a = b;
 			b = temp;
-		}
-	}
-
-	private void removeConnection(EleConnector start, EleConnector end) {
-		EleConnector a = start, b = end;
-		for (int i = 0; i < 2; i++) {
-			if (roadGraph.containsKey(a)) {
-				List<RoadNetworkEdge> edges = roadGraph.get(a);
-				for (RoadNetworkEdge edge : edges) {
-					if (edge.a == a && edge.b == b) {
-						edge.distance = Double.POSITIVE_INFINITY;
-					}
-					if (edge.a == b && edge.b == a) {
-						edge.distance = Double.POSITIVE_INFINITY;
-					}
-				}
-			}
-		}
-	}
-
-	private void interpolateConnection(List<EleConnector> center, EleConnector start, EleConnector end,
-			boolean isSide) {
-		if (center.size() == 0) {
-			return;
-		}
-		removeConnection(start, end);
-		if (isSide) {
-			addConnectionToGraph(start, center.get(0), 0);
-			addConnectionToGraph(center.get(center.size() - 1), end, 0);
-		} else {
-			addConnectionToGraph(start, center.get(0));
-			addConnectionToGraph(center.get(center.size() - 1), end);
-		}
-		for (int i = 1; i < center.size(); i++) {
-			addConnectionToGraph(center.get(i - 1), center.get(i));
 		}
 	}
 

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -194,8 +194,20 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 					MapNode mn = (MapNode) c.reference;
 					List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
 					roads.forEach((road) -> {
-						//System.out.println(road);
-						road.getPrimaryMapElement().getEndNode();
+						MapNode start = road.getPrimaryMapElement().getStartNode();
+						MapNode end = road.getPrimaryMapElement().getEndNode();
+						// System.out.println(road);
+						road.getPrimaryMapElement().getEndNode();// mapNodeToEleconnector
+						/*
+						 * if (road.getPrimaryMapElement().getEndNode() != mn) {
+						 * System.out.println("endnode!=reference"); }
+						 */
+						if (!mapNodeToEleconnector.containsKey(start) || !mapNodeToEleconnector.containsKey(end)) {
+							System.out.println("not contained in map");
+						}
+						// System.out.printf("start:%s end:%s reference:%s\n",
+						// road.getPrimaryMapElement().getStartNode(),
+						// road.getPrimaryMapElement().getEndNode(), mn);
 						road.getPrimaryMapElement().getStartNode();
 					});
 				}

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -55,65 +55,10 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		public EleConnector b;
 		public double distance;
 
-		public static final double dx = 2f;
-
-		public List<Double> h = new ArrayList<Double>();
-		public List<Double> h1 = new ArrayList<Double>();
-
 		public RoadNetworkEdge(EleConnector start, EleConnector end, double d) {
 			a = start;
 			b = end;
 			distance = d;
-			for (int i = 0; i < /* distance / dx + 2 */2; i++) {
-				h.add(0.0);
-				h1.add(0.0);
-			}
-		}
-
-		// calculate diffusion
-		public void step(double dt, double conductance) {
-			{
-				int i = 0;
-				double dhdt = conductance * (h.get(i + 1) - h.get(i)) / dx;
-				h1.set(i, h.get(i) + dhdt * dt);
-			}
-			{
-				int i = h.size() - 1;
-				double dhdt = conductance * (h.get(i - 1) - h.get(i)) / dx;
-				h1.set(i, h.get(i) + dhdt * dt);
-			}
-			for (int i = 1; i < h.size() - 1; i++) {
-				double dhdt = conductance * (h.get(i + 1) - 2 * h.get(i) + h.get(i - 1)) / dx;
-				h1.set(i, h.get(i) + dhdt * dt);
-			}
-			for (int i = 0; i < h.size(); i++) {
-				h.set(i, h1.get(i));
-			}
-			if(h.get(0)!=h.get(1)){
-				System.out.println(h);
-			}
-		}
-
-		public void setStartEnd(double start, double end) {
-			h.set(0, start);
-			h.set(h.size() - 1, end);
-		}
-
-		public double getStart() {
-			return h.get(0);
-		}
-
-		public double getEnd() {
-			return h.get(h.size() - 1);
-		}
-
-		public double getHeight(double pos/* between 0 and 1 */) {
-			int index = (int) Math.floor(pos * (h.size() - 1));
-			if (index >= h.size() - 1) {
-				return getEnd();
-			}
-			double interpolation = pos * (h.size() - 1.0) - index;
-			return h.get(index) * interpolation + h.get(index + 1) * (1 - interpolation);
 		}
 	}
 
@@ -286,8 +231,18 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 					}
 					EleConnector a = mapNodeToEleconnector.get(start);
 					EleConnector b = mapNodeToEleconnector.get(end);
-					addConnectionToGraph(c, b);
-					addConnectionToGraph(c, a);
+
+					List<EleConnector> center = road.getCenterlineEleConnectors();
+					if (center.size() == 0) {
+						addConnectionToGraph(c, b);
+						addConnectionToGraph(c, a);
+					} else {
+						addConnectionToGraph(a, center.get(0));
+						addConnectionToGraph(b, center.get(center.size() - 1));
+						for (int i = 0; i < center.size() - 1; i++) {
+							addConnectionToGraph(center.get(i), center.get(i + 1));
+						}
+					}
 					// AddConnection(a, b, heightMap);
 				});
 			}
@@ -327,54 +282,36 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 				double dhdt = 0;
 				double h = heightMap.get(a);
 				for (RoadNetworkEdge edge : roadGraph.get(a)) {
-					edge.setStartEnd(heightMap.get(a), heightMap.get(edge.b));
-					edge.step(dt, conductance);
-					heightMap1.put(a, edge.getStart());
-					// heightMap1.put(edge.b, edge.getEnd());
-					// dhdt -= conductance * Math.min(1, 1.0 / edge.distance) * (h -
-					// heightMap.get(edge.b));
+					dhdt -= conductance * Math.min(1, 1.0 / edge.distance) * (h - heightMap.get(edge.b));
 				}
-				// double dhdt = 0;
-				// double h = heightMap.get(a);
-				// for (RoadNetworkEdge edge : roadGraph.get(a)) {
-				// dhdt -= conductance * Math.min(1, 1.0 / edge.distance) * (h -
-				// heightMap.get(edge.b));
-				// }
-				// heightMap1.put(a, dhdt * dt + h);
+				heightMap1.put(a, dhdt * dt + h);
 			}
 			for (EleConnector c : connectors) {
 				heightMap.put(c, heightMap1.get(c));
 			}
 		}
-
-		for (EleConnector c : connectors) {
-			if (c.reference instanceof MapNode) {
-				MapNode mn = (MapNode) c.reference;
-				List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
-				roads.forEach((road) -> {
-					MapNode start = road.getPrimaryMapElement().getStartNode();
-					MapNode end = road.getPrimaryMapElement().getEndNode();
-					EleConnector a = mapNodeToEleconnector.get(start);
-					EleConnector b = mapNodeToEleconnector.get(end);
-					try {
-						List<EleConnector> center = road.getCenterlineEleConnectors();
-						interpolateConnection(heightMap, center, a, b, false);
-					} catch (Exception e) {
-						// System.out.println("center" + e.getStackTrace());
-					}
-					try {
-						List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
-						interpolateConnection(heightMap, left, a, b, true);
-					} catch (Exception e) {
-					}
-					try {
-						List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
-						interpolateConnection(heightMap, right, a, b, true);
-					} catch (Exception e) {
-					}
-				});
-			}
-		}
+		// apply heights to center lane
+		// for (EleConnector c : connectors) {
+		// 	if (c.reference instanceof MapNode) {
+		// 		MapNode mn = (MapNode) c.reference;
+		// 		List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+		// 		roads.forEach((road) -> {
+		// 			MapNode start = road.getPrimaryMapElement().getStartNode();
+		// 			MapNode end = road.getPrimaryMapElement().getEndNode();
+		// 			EleConnector a = mapNodeToEleconnector.get(start);
+		// 			EleConnector b = mapNodeToEleconnector.get(end);
+		// 			List<EleConnector> center = road.getCenterlineEleConnectors();
+		// 			try {
+		// 				List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
+		// 			} catch (Exception e) {
+		// 			}
+		// 			try {
+		// 				List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
+		// 			} catch (Exception e) {
+		// 			}
+		// 		});
+		// 	}
+		// }
 		for (EleConnector c : connectors) {
 			double h = heightMap.get(c);
 			c.setPosXYZ(c.getPosXYZ().addY(h));

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -154,7 +154,6 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 	@Override
 	public void requireVerticalDistance(ConstraintType type, double distance, EleConnector upper, EleConnector lower) {
 		// TODO Auto-generated method stub
-		addConnection(upper, lower);
 
 	}
 
@@ -162,26 +161,16 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 	public void requireVerticalDistance(ConstraintType type, double distance, EleConnector upper, EleConnector base1,
 			EleConnector base2) {
 		// TODO Auto-generated method stub
-		addConnection(upper, base1);
-		addConnection(upper, base2);
-
 	}
 
 	@Override
 	public void requireIncline(ConstraintType type, double incline, List<EleConnector> cs) {
 		// TODO Auto-generated method stub
-		connectedCount++;
-		for (int i = 0; i < cs.size() - 1; i++) {
-			addConnection(cs.get(i), cs.get(i + 1));
-		}
 	}
 
 	@Override
 	public void requireSmoothness(EleConnector from, EleConnector via, EleConnector to) {
 		// TODO Auto-generated method stub
-		connectedCount++;
-		addConnection(from, via);
-		addConnection(via, to);
 	}
 
 	@Override
@@ -205,25 +194,11 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			}
 
 		}
-		/*
-		 * for (int i = 0; i < roadConnections.size(); i++) { RoadConnection con =
-		 * roadConnections.get(i); for (int j = 0; j < con.connectors.size(); j++) {
-		 * EleConnector me = con.connectors.get(j); if
-		 * (!roadConnectedTo.containsKey(me)) { roadConnectedTo.put(me, new
-		 * ArrayList<EleConnector>()); } List<EleConnector> targetList =
-		 * roadConnectedTo.get(me); for (int k = 0; k < con.connectors.size(); k++) { if
-		 * (j != k) { EleConnector connector=con.connectors.get(k);
-		 * if(targetList.contains(connector)){ targetList.add(connector); } } }
-		 * System.out.println(targetList.size()); } System.out.println(con); }
-		 */
-		/*
-		 * for (Map.Entry<EleConnector, List<EleConnector>> entry :
-		 * roadConnectedTo.entrySet()) { System.out.println(entry.getValue()); }
-		 */
-
 		for (EleConnector c : connectors) {
 			// TODO use clearing
-
+			if(c.reference!=null){
+				System.out.println(c.reference.getClass().getName());
+			}
 			switch (c.groundState) {
 				case ABOVE:
 					c.setPosXYZ(c.getPosXYZ().addY(5));
@@ -237,60 +212,6 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			}
 			heightMap.put(c, c.getPosXYZ().y);
 		}
-		// integrator code
-		double dt = 0.1;// dt
-		for (int step = 0; step < 100; step++) {
-			for (Map.Entry<EleConnector, List<EleConnector>> entry : roadConnectedTo.entrySet()) {
-				EleConnector source = entry.getKey();
-				if (source == null) {
-					continue;
-				}
-				double dhdt = 0;// dh/dt
-				double myheight = heightMap.get(source);
-				List<EleConnector> others = entry.getValue();
-				List<Double> coupling = new ArrayList<Double>();
-				for (int i = 0; i < others.size(); i++) {
-					EleConnector other = others.get(i);
-					double cc = 0;
-					coupling.add(cc);
-					if (other == null) {
-						continue;
-					}
-					double distance = other.pos.distanceTo(source.pos);
-					// diverge avoidance
-					if (distance < 0.3) {
-						distance = 0.3;
-					}
-					cc = 1 / distance;
-					coupling.set(0, cc);
-					dhdt += (heightMap.get(other) - myheight) / others.size();
-				}
-				source.setPosXYZ(source.getPosXYZ().addY(dhdt * dt));
-			}
-			// apply constant temperature boundary
-			for (EleConnector c : connectors) {
-				// TODO use clearing
-
-				switch (c.groundState) {
-					case ABOVE: {
-						VectorXYZ coord = c.getPosXYZ();
-						c.setPosXYZ(new VectorXYZ(coord.x, 5, coord.z));
-						// System.out.println("SimpleEleConstraintEnforcer:ABOVE");
-						break;
-					}
-					case BELOW: {
-						VectorXYZ coord = c.getPosXYZ();
-						c.setPosXYZ(new VectorXYZ(coord.x, -5, coord.z));
-						// System.out.println("SimpleEleConstraintEnforcer:BELOW");
-						break;
-					}
-					default: // stay at ground elevation
-				}
-				heightMap.put(c, c.getPosXYZ().y);
-			}
-		}
-
-		// System.out.print("connectedCount:"+connectedCount);
 	}
 
 	/**

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -1,0 +1,254 @@
+package org.osm2world.core.map_elevation.creation;
+
+import static java.util.Arrays.asList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.osm2world.core.map_elevation.data.EleConnector;
+
+/**
+ * enforcer implementation that ignores many of the constraints, but is much
+ * faster than the typical full implementation.
+ *
+ * It tries to produce an output that is "good enough" for some purposes, and is
+ * therefore a compromise between the {@link NoneEleConstraintEnforcer} and a
+ * full implementation.
+ */
+
+public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforcer {
+
+	private Collection<EleConnector> connectors = new ArrayList<EleConnector>();
+
+	/**
+	 * associates each EleConnector with the {@link StiffConnectorSet} it is part of
+	 * (if any)
+	 */
+	private Map<EleConnector, StiffConnectorSet> stiffSetMap = new HashMap<EleConnector, StiffConnectorSet>();
+
+	int connectedCount=0;
+
+	@Override
+	public void addConnectors(Iterable<EleConnector> newConnectors) {
+
+		for (EleConnector c : newConnectors) {
+			connectors.add(c);
+		}
+
+		/* connect connectors */
+
+		for (EleConnector c1 : newConnectors) {
+			for (EleConnector c2 : connectors) {
+
+				if (c1 != c2 && c1.connectsTo(c2)) {
+					requireSameEle(c1, c2);
+				}
+
+			}
+		}
+
+	}
+
+	@Override
+	public void requireSameEle(EleConnector c1, EleConnector c2) {
+
+		// SUGGEST (performance): a special case implementation would be faster
+
+		requireSameEle(asList(c1, c2));
+
+	}
+
+	@Override
+	public void requireSameEle(Iterable<EleConnector> cs) {
+
+		/* find stiff sets containing any of the affected connectors */
+
+		Set<EleConnector> looseConnectors = new HashSet<EleConnector>();
+		Set<StiffConnectorSet> existingStiffSets = new HashSet<StiffConnectorSet>();
+
+		for (EleConnector c : cs) {
+
+			StiffConnectorSet stiffSet = stiffSetMap.get(c);
+
+			if (stiffSet != null) {
+				existingStiffSets.add(stiffSet);
+			} else {
+				looseConnectors.add(c);
+			}
+
+		}
+
+		/* return if the connectors are already in a set together */
+
+		if (existingStiffSets.size() == 1 && looseConnectors.isEmpty())
+			return;
+
+		/* merge existing sets (if any) into a single set */
+
+		StiffConnectorSet commonStiffSet = null;
+
+		if (existingStiffSets.isEmpty()) {
+			commonStiffSet = new StiffConnectorSet();
+		} else {
+
+			for (StiffConnectorSet stiffSet : existingStiffSets) {
+
+				if (commonStiffSet == null) {
+					commonStiffSet = stiffSet;
+				} else {
+
+					for (EleConnector c : stiffSet) {
+						stiffSetMap.put(c, commonStiffSet);
+					}
+
+					commonStiffSet.mergeFrom(stiffSet);
+
+				}
+
+			}
+
+		}
+
+		/* add remaining (loose) connectors into the common set */
+
+		for (EleConnector c : looseConnectors) {
+
+			commonStiffSet.add(c);
+
+			stiffSetMap.put(c, commonStiffSet);
+
+		}
+
+	}
+
+	@Override
+	public void requireVerticalDistance(ConstraintType type, double distance, EleConnector upper, EleConnector lower) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void requireVerticalDistance(ConstraintType type, double distance, EleConnector upper, EleConnector base1,
+			EleConnector base2) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void requireIncline(ConstraintType type, double incline, List<EleConnector> cs) {
+		// TODO Auto-generated method stub
+		connectedCount++;
+
+	}
+
+	@Override
+	public void requireSmoothness(EleConnector from, EleConnector via, EleConnector to) {
+		// TODO Auto-generated method stub
+		connectedCount++;
+	}
+
+	@Override
+	public void enforceConstraints() {
+
+		/* assign elevation to stiff sets by averaging terrain elevation */
+		// TODO what for stiff sets above the ground?
+		System.out.println("SimpleEleConstraintEnforcer:enforceConstraints");
+		for (StiffConnectorSet stiffSet : stiffSetMap.values()) {
+
+			double averageEle = 0;
+
+			for (EleConnector connector : stiffSet) {
+				averageEle += connector.getPosXYZ().y;
+			}
+
+			averageEle /= stiffSet.size();
+
+			for (EleConnector connector : stiffSet) {
+				connector.setPosXYZ(connector.pos.xyz(averageEle));
+			}
+
+		}
+
+		/*
+		 * TODO implement intended algorithm: - first assign ground ele to ON - then
+		 * assign ele for ABOVE and BELOW based on min vertical distance constraints,
+		 * and clearing
+		 */
+		List<String> types = new ArrayList<String>();
+		for (EleConnector c : connectors) {
+			if (c != null&&c.reference!=null) {
+				String typename = c.reference.getClass().getName();
+				if (types.contains(typename)) {
+					types.add(c.reference.getClass().getName());
+				}
+			}
+			// TODO use clearing
+
+			switch (c.groundState) {
+				case ABOVE:
+					c.setPosXYZ(c.getPosXYZ().addY(5));
+					// System.out.println("SimpleEleConstraintEnforcer:ABOVE");
+					break;
+				case BELOW:
+					c.setPosXYZ(c.getPosXYZ().addY(-5));
+					// System.out.println("SimpleEleConstraintEnforcer:BELOW");
+					break;
+				default: // stay at ground elevation
+			}
+
+		}
+
+		for (int i = 0; i < types.size(); i++) {
+			System.out.println(types.get(i));
+		}
+		//System.out.print("connectedCount:"+connectedCount);
+	}
+
+	/**
+	 * a set of connectors that are required to have the same elevation TODO or a
+	 * precise vertical offset
+	 */
+	private static class StiffConnectorSet implements Iterable<EleConnector> {
+
+		// TODO maybe look for a more efficient set implementation
+		private Set<EleConnector> connectors = new HashSet<EleConnector>();
+
+		/**
+		 * adds a connector to this set, requiring it to be at the set's reference
+		 * elevation
+		 */
+		public void add(EleConnector connector) {
+			connectors.add(connector);
+		}
+
+		/**
+		 * combines this set with another, and makes the other set unusable. This set
+		 * will contain all {@link EleConnector}s from the other set afterwards.
+		 */
+		public void mergeFrom(StiffConnectorSet otherSet) {
+
+			connectors.addAll(otherSet.connectors);
+
+			// make sure that the other set cannot be used anymore
+			otherSet.connectors = null;
+
+		}
+
+		public double size() {
+			return connectors.size();
+		}
+
+		@Override
+		public Iterator<EleConnector> iterator() {
+			return connectors.iterator();
+		}
+
+	}
+
+}

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -237,11 +237,16 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 						addConnectionToGraph(c, b);
 						addConnectionToGraph(c, a);
 					} else {
+						if (c.getPosXYZ().distanceToXZ(b.getPosXYZ()) > c.getPosXYZ().distanceToXZ(a.getPosXYZ())) {
+							addConnectionToGraph(c, a);
+						} else {
+							addConnectionToGraph(c, b);
+						}
 						addConnectionToGraph(a, center.get(0));
-						addConnectionToGraph(b, center.get(center.size() - 1));
 						for (int i = 0; i < center.size() - 1; i++) {
 							addConnectionToGraph(center.get(i), center.get(i + 1));
 						}
+						addConnectionToGraph(center.get(center.size() - 1), b);
 					}
 					// AddConnection(a, b, heightMap);
 				});
@@ -261,9 +266,9 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			heightMap.put(c, h);
 			heightMap1.put(c, h);
 		}
-		double dt = 0.1;
+		double dt = 0.01;
 		double conductance = 1;
-		for (double t = 0; t < 10; t += dt) {
+		for (double t = 0; t < 3; t += dt) {
 			for (EleConnector c : connectors) {
 				double h = heightMap.get(c);
 				switch (c.groundState) {
@@ -275,14 +280,14 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 						break;
 					default: // stay at ground elevation
 				}
-				heightMap.put(c, h);
-				heightMap1.put(c, h);
+				// heightMap.put(c, h);
+				// heightMap1.put(c, h);
 			}
 			for (EleConnector a : roadGraph.keySet()) {
 				double dhdt = 0;
 				double h = heightMap.get(a);
 				for (RoadNetworkEdge edge : roadGraph.get(a)) {
-					dhdt -= conductance * Math.min(1, 1.0 / edge.distance) * (h - heightMap.get(edge.b));
+					dhdt -= conductance * Math.min(5, 1.0 / edge.distance) * (h - heightMap.get(edge.b));
 				}
 				heightMap1.put(a, dhdt * dt + h);
 			}
@@ -292,25 +297,27 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		}
 		// apply heights to center lane
 		// for (EleConnector c : connectors) {
-		// 	if (c.reference instanceof MapNode) {
-		// 		MapNode mn = (MapNode) c.reference;
-		// 		List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
-		// 		roads.forEach((road) -> {
-		// 			MapNode start = road.getPrimaryMapElement().getStartNode();
-		// 			MapNode end = road.getPrimaryMapElement().getEndNode();
-		// 			EleConnector a = mapNodeToEleconnector.get(start);
-		// 			EleConnector b = mapNodeToEleconnector.get(end);
-		// 			List<EleConnector> center = road.getCenterlineEleConnectors();
-		// 			try {
-		// 				List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
-		// 			} catch (Exception e) {
-		// 			}
-		// 			try {
-		// 				List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
-		// 			} catch (Exception e) {
-		// 			}
-		// 		});
-		// 	}
+		// if (c.reference instanceof MapNode) {
+		// MapNode mn = (MapNode) c.reference;
+		// List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+		// roads.forEach((road) -> {
+		// MapNode start = road.getPrimaryMapElement().getStartNode();
+		// MapNode end = road.getPrimaryMapElement().getEndNode();
+		// EleConnector a = mapNodeToEleconnector.get(start);
+		// EleConnector b = mapNodeToEleconnector.get(end);
+		// List<EleConnector> center = road.getCenterlineEleConnectors();
+		// try {
+		// List<EleConnector> left =
+		// road.connectors.getConnectors(road.getOutlineXZ(false));
+		// } catch (Exception e) {
+		// }
+		// try {
+		// List<EleConnector> right =
+		// road.connectors.getConnectors(road.getOutlineXZ(true));
+		// } catch (Exception e) {
+		// }
+		// });
+		// }
 		// }
 		for (EleConnector c : connectors) {
 			double h = heightMap.get(c);
@@ -392,7 +399,6 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 				}
 				if (!found) {
 					edges.add(new RoadNetworkEdge(a, b, distance));
-					roadGraph.put(a, edges);
 				}
 			} else {
 				List<RoadNetworkEdge> edges = new ArrayList<RoadNetworkEdge>();

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -22,6 +22,7 @@ import org.osm2world.core.map_data.data.MapWaySegment;
 import org.osm2world.core.map_elevation.data.EleConnector;
 import org.osm2world.core.map_elevation.data.GroundState;
 import org.osm2world.core.math.VectorXYZ;
+import org.osm2world.core.target.common.material.Material.Interpolation;
 import org.osm2world.core.world.data.NodeWorldObject;
 import org.osm2world.core.world.modules.BridgeModule;
 import org.osm2world.core.world.modules.RoadModule;
@@ -350,11 +351,54 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		if (from.size() == 0) {
 			return;
 		}
-		double conversionratio = (double) from.size() / to.size();
-		for (int i = 0; i < to.size(); i++) {
-			int i_from = (int) Math.round((double) (i * conversionratio));
-			i_from = i_from >= from.size() ? from.size() : i_from;
-			heightMap.put(to.get(i), heightMap.get(from.get(i_from)));
+
+		List<Double> hs = new ArrayList<Double>();
+		List<Double> xs = new ArrayList<Double>();
+		{
+			double l = 0;
+			VectorXYZ before = from.get(0).getPosXYZ();
+			for (int i = 0; i < from.size(); i++) {
+				VectorXYZ pos = from.get(i).getPosXYZ();
+				l += pos.distanceToXZ(before);
+
+				hs.add(heightMap.get(from.get(i)));
+				xs.add(l);
+				before = pos;
+			}
+		}
+		double total = 0;
+		{
+			VectorXYZ before = to.get(0).getPosXYZ();
+			for (int i = 0; i < from.size(); i++) {
+				VectorXYZ pos = from.get(i).getPosXYZ();
+				total += pos.distanceToXZ(before);
+			}
+		}
+		{
+			double l = 0;
+			VectorXYZ before = to.get(0).getPosXYZ();
+			for (EleConnector target : to) {
+				VectorXYZ pos = target.getPosXYZ();
+				l += pos.distanceToXZ(before);
+				boolean found = false;
+				heightMap.put(target, hs.get(0));
+				for (int i = 1; i < from.size(); i++) {
+					double x = l / total;
+					double x1 = xs.get(i) / xs.get(xs.size() - 1);
+					double h1 = hs.get(i);
+					double x2 = xs.get(i - 1) / xs.get(xs.size() - 1);
+					double h2 = hs.get(i - 1);
+					if (x1 >= x) {
+						found = true;
+						heightMap.put(target, (h1 * (x - x2) + h2 * (x1 - x)) / (x1 - x2));
+						break;
+					}
+				}
+				if(!found){
+					heightMap.put(target, hs.get(hs.size()-1));
+				}
+
+			}
 		}
 	}
 

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -11,8 +11,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.osm2world.core.map_data.data.MapNode;
 import org.osm2world.core.map_elevation.data.EleConnector;
 import org.osm2world.core.math.VectorXYZ;
+import org.osm2world.core.world.data.NodeWorldObject;
+import org.osm2world.core.world.modules.RoadModule;
+import org.osm2world.core.world.modules.RoadModule.Road;
 
 /**
  * enforcer implementation that ignores many of the constraints, but is much
@@ -196,8 +200,16 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		}
 		for (EleConnector c : connectors) {
 			// TODO use clearing
-			if(c.reference!=null){
+			if (c.reference != null) {
 				System.out.println(c.reference.getClass().getName());
+				if (c.reference instanceof MapNode) {
+					MapNode mn = (MapNode) c.reference;
+					List<Road> roads=RoadModule.getConnectedRoads(mn,true);
+					roads.forEach((road)->{
+						System.out.println(road);
+					});
+				}
+
 			}
 			switch (c.groundState) {
 				case ABOVE:

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -231,29 +231,38 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 						}
 						EleConnector a = mapNodeToEleconnector.get(start);
 						EleConnector b = mapNodeToEleconnector.get(end);
-						point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.getPosXYZ().y, c.getPosXYZ().z);
-						point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.getPosXYZ().y, a.getPosXYZ().z);
-						point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.getPosXYZ().y, b.getPosXYZ().z);
-
-						if (a != b) {
-							for (int i = 0; i < 2; i++) {
-								if (a.groundState == GroundState.ON) {
-									if (b.groundState == GroundState.ABOVE) {
-										heightMap.put(b, 4.0);
-										heightMap.put(a, 2.0);
-										VectorXYZ cpos = c.getPosXYZ();
-										if (a.getPosXYZ().distanceToXZ(cpos) < b.getPosXYZ().distanceToXZ(cpos)) {
-											heightMap.put(c, 2.0);
-										} else {
-											heightMap.put(c, 2.0);
-										}
-									}
-								}
-								EleConnector temp = a;
-								a = b;
-								b = temp;
+						point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState==GroundState.ABOVE?10.0:5.0,c.getPosXYZ().z);
+						point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState==GroundState.ABOVE?5.0:0.0,a.getPosXYZ().z);
+						point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState==GroundState.ABOVE?5.0:0.0,b.getPosXYZ().z);
+						if (c.groundState == GroundState.ON) {
+							if (a.groundState == GroundState.ABOVE||b.groundState == GroundState.ABOVE) {
+								heightMap.put(c, 2.0);
 							}
 						}
+						if (c.groundState == GroundState.ABOVE) {
+							if (a.groundState == GroundState.ON||b.groundState == GroundState.ON) {
+								heightMap.put(c, 4.0);
+							}
+						}
+						// if (a != b) {
+						// 	for (int i = 0; i < 2; i++) {
+						// 		if (a.groundState == GroundState.ON) {
+						// 			if (b.groundState == GroundState.ABOVE) {
+						// 				heightMap.put(b, 4.0);
+						// 				heightMap.put(a, 2.0);
+						// 				VectorXYZ cpos = c.getPosXYZ();
+						// 				if (a.getPosXYZ().distanceToXZ(cpos) < b.getPosXYZ().distanceToXZ(cpos)) {
+						// 					heightMap.put(c, 2.0);
+						// 				} else {
+						// 					heightMap.put(c, 2.0);
+						// 				}
+						// 			}
+						// 		}
+						// 		EleConnector temp = a;
+						// 		a = b;
+						// 		b = temp;
+						// 	}
+						// }
 						// for (int i = 0; i < 2; i++) {
 						// if (a != c) {
 						// if (a.groundState == GroundState.ON) {
@@ -274,11 +283,11 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 					});
 				}
 			}
+			point_out.flush();
 		} catch (FileNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-
 		// final double dt = 0.05;
 		// for (int step = 0; step < 10; step++) {
 		// // heightMap:old

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.apache.batik.bridge.Bridge;
 import org.osm2world.core.map_data.data.MapNode;
 import org.osm2world.core.map_data.data.MapWaySegment;
@@ -266,77 +268,37 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 						}
 						// System.out.println("road.getCenterline().size()" +
 						// road.getCenterline().size());
-						List<EleConnector> center = road.getCenterlineEleConnectors();
-						//List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
-						//List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
-						for (int i = 1; i < center.size(); i++) {
-							EleConnector a = center.get(i-1);
-							EleConnector b = center.get(i);
-							point_out.printf("%f,%f,%f\n", c.getPosXYZ().x,
-									c.groundState == GroundState.ABOVE ? 15.0 : 5.0, c.getPosXYZ().z);
-							point_out.printf("%f,%f,%f\n", a.getPosXYZ().x,
-									a.groundState == GroundState.ABOVE ? 10.0 : 0.0, a.getPosXYZ().z);
-							point_out.printf("%f,%f,%f\n", b.getPosXYZ().x,
-									b.groundState == GroundState.ABOVE ? 10.0 : 0.0, b.getPosXYZ().z);
+						// List<EleConnector> left =
+						// road.connectors.getConnectors(road.getOutlineXZ(false));
+						// List<EleConnector> right =
+						// road.connectors.getConnectors(road.getOutlineXZ(true));
+						EleConnector a = mapNodeToEleconnector.get(start);
+						EleConnector b = mapNodeToEleconnector.get(end);
+						AddConnection(c, b, heightMap);
+						AddConnection(c, a, heightMap);
+						//AddConnection(a, b, heightMap);
+						if (true) {
+							return;
 						}
-						// {
-						// EleConnector a = mapNodeToEleconnector.get(start);
-						// EleConnector b = mapNodeToEleconnector.get(end);
-						// point_out.printf("%f,%f,%f\n", c.getPosXYZ().x,
-						// c.groundState == GroundState.ABOVE ? 15.0 : 5.0, c.getPosXYZ().z);
-						// point_out.printf("%f,%f,%f\n", a.getPosXYZ().x,
-						// a.groundState == GroundState.ABOVE ? 10.0 : 0.0, a.getPosXYZ().z);
-						// point_out.printf("%f,%f,%f\n", b.getPosXYZ().x,
-						// b.groundState == GroundState.ABOVE ? 10.0 : 0.0, b.getPosXYZ().z);
 
-						// if (c.groundState == GroundState.ON) {
-						// if (a.groundState == GroundState.ABOVE || b.groundState == GroundState.ABOVE)
-						// {
-						// heightMap.put(c, 2.0);
-						// }
-						// }
-						// if (c.groundState == GroundState.ABOVE) {
-						// if (a.groundState == GroundState.ON || b.groundState == GroundState.ON) {
-						// heightMap.put(c, 4.0);
-						// }
-						// }
-						// }
-						// if (a != b) {
-						// for (int i = 0; i < 2; i++) {
-						// if (a.groundState == GroundState.ON) {
-						// if (b.groundState == GroundState.ABOVE) {
-						// heightMap.put(b, 4.0);
-						// heightMap.put(a, 2.0);
-						// VectorXYZ cpos = c.getPosXYZ();
-						// if (a.getPosXYZ().distanceToXZ(cpos) < b.getPosXYZ().distanceToXZ(cpos)) {
-						// heightMap.put(c, 2.0);
-						// } else {
-						// heightMap.put(c, 2.0);
-						// }
-						// }
-						// }
-						// EleConnector temp = a;
-						// a = b;
-						// b = temp;
-						// }
-						// }
-						// for (int i = 0; i < 2; i++) {
-						// if (a != c) {
-						// if (a.groundState == GroundState.ON) {
-						// if (c.groundState == GroundState.ABOVE) {
-						// heightMap.put(c, 4.0);
-						// heightMap.put(a, 2.0);
-						// }
-						// }
-						// if (a.groundState == GroundState.ABOVE) {
-						// if (c.groundState == GroundState.ON) {
-						// heightMap.put(c, 2.0);
-						// heightMap.put(a, 4.0);
-						// }
-						// }
-						// }
-						// a = b;
-						// }
+						try {
+							List<EleConnector> center = road.getCenterlineEleConnectors();
+							DebugConnection(heightMap, center, point_out, c, a, b);
+						} catch (Exception e) {
+							System.out.println("center" + e.getStackTrace());
+						}
+						try {
+							List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
+							DebugConnection(heightMap, left, point_out, c, a, b);
+						} catch (Exception e) {
+							// System.out.println(e.getStackTrace());
+						}
+						try {
+							List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
+							DebugConnection(heightMap, right, point_out, c, a, b);
+						} catch (Exception e) {
+							// System.out.println(e.getStackTrace());
+						}
 					});
 				}
 			}
@@ -346,46 +308,11 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		// final double dt = 0.05;
-		// for (int step = 0; step < 10; step++) {
-		// // heightMap:old
-		// // apply boundary condition
-		// // roadList.forEach((c) -> {
-		// // for (EleConnector c : roadList) {
-		// // switch (c.groundState) {
-		// // case ABOVE:
-		// // heightMap.put(c, 5.0);
-		// // break;
-		// // case BELOW:
-		// // heightMap.put(c, -5.0);
-		// // // System.out.println("SimpleEleConstraintEnforcer:BELOW");
-		// // break;
-		// // default: // stay at ground elevation
-		// // }
-		// // }
-		// // heightMap1:new
-		// for (EleConnector source : roadList) {
-		// double dhdt = 0;
-		// double sourceh = heightMap.get(source);
-		// if (roadConnectedTo.containsKey(source)) {
-		// for (EleConnector target : roadConnectedTo.get(source)) {
-		// double targeth = heightMap.get(target);
-		// dhdt += targeth - sourceh;
-		// }
-		// }
-		// heightMap1.put(source, sourceh + dhdt * dt);
-		// }
-
-		// Map<EleConnector, Double> temp = heightMap;
-		// heightMap = heightMap1;
-		// heightMap1 = temp;
-		// }
 
 		for (EleConnector c : connectors) {
 			// TODO use clearing
 			double h = heightMap.get(c);
 			c.setPosXYZ(c.getPosXYZ().addY(h));
-
 		}
 
 		if (true) {
@@ -402,6 +329,80 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		}
 		// });
 		return;
+	}
+
+	private void DebugConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center, PrintWriter point_out,
+			EleConnector c) {
+		DebugConnection(heightMap, center, point_out, c, null, null);
+	}
+
+	private void AddConnection(EleConnector a, EleConnector b, Map<EleConnector, Double> heightMap) {
+		if (a.groundState == GroundState.ON) {
+			if (b.groundState == GroundState.ABOVE) {
+				// heightMap.put(a, 2.0);
+				heightMap.put(b, 4.0);
+				heightMap.put(a, 2.0);
+			}
+		}
+		if (a.groundState == GroundState.ABOVE) {
+			if (b.groundState == GroundState.ON) {
+				// heightMap.put(a, 4.0);
+				heightMap.put(b, 2.0);
+				heightMap.put(a, 4.0);
+			}
+		}
+	}
+
+	private void DebugConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center, PrintWriter point_out,
+			EleConnector c, @Nullable EleConnector start, @Nullable EleConnector end) {
+
+		if (start != null && center.size() > 0) {
+			EleConnector a = start;
+			EleConnector b = center.get(0);
+			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
+					c.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					a.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					b.getPosXYZ().z);
+			AddConnection(a, b, heightMap);
+		}
+		if (end != null && center.size() > 0) {
+			EleConnector a = end;
+			EleConnector b = center.get(center.size() - 1);
+			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
+					c.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					a.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					b.getPosXYZ().z);
+			AddConnection(a, b, heightMap);
+		}
+		for (int i = 1; i < center.size(); i++) {
+			EleConnector a = center.get(i - 1);
+			EleConnector b = center.get(i);
+			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
+					c.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					a.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					b.getPosXYZ().z);
+			if (a.groundState == GroundState.ON) {
+				if (b.groundState == GroundState.ABOVE) {
+					heightMap.put(a, 2.0);
+					heightMap.put(b, 4.0);
+				}
+			}
+			if (a.groundState == GroundState.ABOVE) {
+				if (b.groundState == GroundState.ON) {
+					heightMap.put(a, 4.0);
+					heightMap.put(b, 2.0);
+				}
+			}
+			// point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, 5.0, c.getPosXYZ().z);
+			// point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, 0.0, a.getPosXYZ().z);
+			// point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, 0.0, b.getPosXYZ().z);
+		}
 	}
 
 	/**

--- a/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/DiffusionEleConstraintEnforcer.java
@@ -50,6 +50,20 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 
 	int connectedCount = 0;
 
+	class RoadNetworkEdge {
+		public EleConnector a;
+		public EleConnector b;
+		public double distance;
+
+		public RoadNetworkEdge(EleConnector start, EleConnector end, double d) {
+			a = start;
+			b = end;
+			distance = d;
+		}
+	}
+
+	Map<EleConnector, List<RoadNetworkEdge>> roadGraph = new HashMap<EleConnector, List<RoadNetworkEdge>>();;
+
 	@Override
 	public void addConnectors(Iterable<EleConnector> newConnectors) {
 
@@ -186,14 +200,87 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			}
 
 		}
+
 		List<EleConnector> roadList = new ArrayList<EleConnector>();
-		Map<EleConnector, List<EleConnector>> roadConnectedTo = new HashMap<EleConnector, List<EleConnector>>();
 
 		Map<MapNode, EleConnector> mapNodeToEleconnector = new HashMap<MapNode, EleConnector>();
 		Map<EleConnector, Double> heightMap = new HashMap<EleConnector, Double>();
 		Map<EleConnector, Double> heightMap1 = new HashMap<EleConnector, Double>();
 
 		// initialize height map
+		// for (EleConnector c : connectors) {
+		// double h = 0;
+		// switch (c.groundState) {
+		// case ABOVE:
+		// h = 5.0;
+		// break;
+		// case BELOW:
+		// h = -5.0;
+		// break;
+		// default: // stay at ground elevation
+		// }
+		// heightMap.put(c, h);
+		// heightMap1.put(c, h);
+		// }
+		// connectors.forEach((c) -> {
+		for (EleConnector c : connectors) {
+			if (c.reference != null) {
+				if (c.reference instanceof MapNode) {
+					MapNode mn = (MapNode) c.reference;
+					mapNodeToEleconnector.put(mn, c);
+				}
+			} else {
+				System.out.println(c);
+			}
+		}
+
+		for (EleConnector c : connectors) {
+			if (c.reference instanceof MapNode) {
+				MapNode mn = (MapNode) c.reference;
+				List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+				roads.forEach((road) -> {
+					MapNode start = road.getPrimaryMapElement().getStartNode();
+					MapNode end = road.getPrimaryMapElement().getEndNode();
+					if (!mapNodeToEleconnector.containsKey(start) || !mapNodeToEleconnector.containsKey(end)) {
+						System.out.println("not contained in map");
+						return;
+					}
+					EleConnector a = mapNodeToEleconnector.get(start);
+					EleConnector b = mapNodeToEleconnector.get(end);
+					addConnectionToGraph(c, b);
+					addConnectionToGraph(c, a);
+					// AddConnection(a, b, heightMap);
+				});
+			}
+		}
+		for (EleConnector c : connectors) {
+			if (c.reference instanceof MapNode) {
+				MapNode mn = (MapNode) c.reference;
+				List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+				roads.forEach((road) -> {
+					MapNode start = road.getPrimaryMapElement().getStartNode();
+					MapNode end = road.getPrimaryMapElement().getEndNode();
+					EleConnector a = mapNodeToEleconnector.get(start);
+					EleConnector b = mapNodeToEleconnector.get(end);
+					try {
+						List<EleConnector> center = road.getCenterlineEleConnectors();
+						interpolateConnection(center, a, b, false);
+					} catch (Exception e) {
+						System.out.println("center" + e.getStackTrace());
+					}
+					try {
+						List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
+						interpolateConnection(left, a, b, true);
+					} catch (Exception e) {
+					}
+					try {
+						List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
+						interpolateConnection(right, a, b, true);
+					} catch (Exception e) {
+					}
+				});
+			}
+		}
 		for (EleConnector c : connectors) {
 			double h = 0;
 			switch (c.groundState) {
@@ -208,83 +295,49 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 			heightMap.put(c, h);
 			heightMap1.put(c, h);
 		}
-		// connectors.forEach((c) -> {
-		for (EleConnector c : connectors) {
-			if (c.reference != null) {
-				if (c.reference instanceof MapNode) {
-					MapNode mn = (MapNode) c.reference;
-					mapNodeToEleconnector.put(mn, c);
-				}
-			} else {
-				System.out.println(c);
-			}
-		}
-		PrintWriter point_out;
-		PrintWriter point_out2;
-		try {
-			point_out = new PrintWriter(new FileOutputStream("roadpoints.csv", false));
-			point_out2 = new PrintWriter(new FileOutputStream("segmentpoints.csv", false));
+		double dt = 0.01;
+		double conductance = 100;
+		for (double t = 0; t < 1; t++) {
 			for (EleConnector c : connectors) {
-				if (c.reference instanceof MapNode) {
-					MapNode mn = (MapNode) c.reference;
-					List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
-
-					roads.forEach((road) -> {
-						MapNode start = road.getPrimaryMapElement().getStartNode();
-						MapNode end = road.getPrimaryMapElement().getEndNode();
-						if (!mapNodeToEleconnector.containsKey(start) || !mapNodeToEleconnector.containsKey(end)) {
-							System.out.println("not contained in map");
-							return;
-						}
-						EleConnector a = mapNodeToEleconnector.get(start);
-						EleConnector b = mapNodeToEleconnector.get(end);
-						AddConnection(c, b, heightMap);
-						AddConnection(c, a, heightMap);
-						// AddConnection(a, b, heightMap);
-					});
+				double h = 0;
+				switch (c.groundState) {
+					case ABOVE:
+						h = 5.0;
+						break;
+					case BELOW:
+						h = -5.0;
+						break;
+					default: // stay at ground elevation
 				}
+				// heightMap.put(c, h);
+				// heightMap1.put(c, h);
+			}
+			for (EleConnector c : roadGraph.keySet()) {
+				for (RoadNetworkEdge edge : roadGraph.get(c)) {
+					if (edge.distance <= 0.1) {
+						double average = heightMap.get(edge.b) + heightMap.get(edge.a);
+						average *= 0.5;
+						heightMap.put(edge.a, average);
+						heightMap.put(edge.b, average);
+					}
+				}
+			}
+			for (EleConnector a : roadGraph.keySet()) {
+				double dhdt = 0;
+				double h = heightMap.get(a);
+				for (RoadNetworkEdge edge : roadGraph.get(a)) {
+					if (edge.distance > 0.1) {
+						dhdt -= conductance / edge.distance * (h - heightMap.get(edge.b));
+					}
+				}
+				heightMap1.put(a, dhdt * dt + h);
 			}
 			for (EleConnector c : connectors) {
-				if (c.reference instanceof MapNode) {
-					MapNode mn = (MapNode) c.reference;
-					List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
-					roads.forEach((road) -> {
-						MapNode start = road.getPrimaryMapElement().getStartNode();
-						MapNode end = road.getPrimaryMapElement().getEndNode();
-						EleConnector a = mapNodeToEleconnector.get(start);
-						EleConnector b = mapNodeToEleconnector.get(end);
-						try {
-							List<EleConnector> center = road.getCenterlineEleConnectors();
-							interpolateConnection(heightMap, center, a, b, false);
-						} catch (Exception e) {
-							System.out.println("center" + e.getStackTrace());
-						}
-						try {
-							List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
-							interpolateConnection(heightMap, left, a, b, true);
-						} catch (Exception e) {
-							// System.out.println(e.getStackTrace());
-						}
-						try {
-							List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
-							interpolateConnection(heightMap, right, a, b, true);
-						} catch (Exception e) {
-							// System.out.println(e.getStackTrace());
-						}
-					});
-				}
+				heightMap.put(c, heightMap1.get(c));
 			}
-			point_out.flush();
-			point_out2.flush();
-		} catch (
-
-		FileNotFoundException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
 		}
 
 		for (EleConnector c : connectors) {
-			// TODO use clearing
 			double h = heightMap.get(c);
 			c.setPosXYZ(c.getPosXYZ().addY(h));
 		}
@@ -305,117 +358,75 @@ public final class DiffusionEleConstraintEnforcer implements EleConstraintEnforc
 		return;
 	}
 
-	private void DebugConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center, PrintWriter point_out,
-			EleConnector c) {
-		DebugConnection(heightMap, center, point_out, c, null, null);
+	// add connection to node edges
+	private void addConnectionToGraph(EleConnector start, EleConnector end) {
+		addConnectionToGraph(start, end, start.getPosXYZ().distanceToXZ(end.getPosXYZ()));
 	}
 
-	private void AddConnection(EleConnector a, EleConnector b, Map<EleConnector, Double> heightMap) {
-		if (a.groundState == GroundState.ON) {
-			if (b.groundState == GroundState.ABOVE) {
-				// heightMap.put(a, 2.0);
-				heightMap.put(b, 4.0);
-				heightMap.put(a, 2.0);
+	// add connection to node edges
+	private void addConnectionToGraph(EleConnector start, EleConnector end, double distance) {
+		EleConnector a = start, b = end;
+		for (int i = 0; i < 2; i++) {
+			if (roadGraph.containsKey(a)) {
+				boolean found = false;
+				for (RoadNetworkEdge edge : roadGraph.get(a)) {
+					if (edge.a == a && edge.b == b) {
+						found = true;
+						break;
+					}
+					if (edge.a == b && edge.b == a) {
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
+					List<RoadNetworkEdge> edges = new ArrayList<RoadNetworkEdge>();
+					edges.add(new RoadNetworkEdge(a, b, distance));
+					roadGraph.put(a, edges);
+				}
+			} else {
+				List<RoadNetworkEdge> edges = new ArrayList<RoadNetworkEdge>();
+				edges.add(new RoadNetworkEdge(a, b, distance));
+				roadGraph.put(a, edges);
 			}
-		}
-		if (a.groundState == GroundState.ABOVE) {
-			if (b.groundState == GroundState.ON) {
-				// heightMap.put(a, 4.0);
-				heightMap.put(b, 2.0);
-				heightMap.put(a, 4.0);
-			}
+			EleConnector temp = a;
+			a = b;
+			b = temp;
 		}
 	}
 
-	private void DebugConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center, PrintWriter point_out,
-			EleConnector c, @Nullable EleConnector start, @Nullable EleConnector end) {
-
-		if (start != null && center.size() > 0) {
-			EleConnector a = start;
-			EleConnector b = center.get(0);
-			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
-					c.getPosXYZ().z);
-			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
-					a.getPosXYZ().z);
-			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
-					b.getPosXYZ().z);
-			AddConnection(a, b, heightMap);
-		}
-		if (end != null && center.size() > 0) {
-			EleConnector a = end;
-			EleConnector b = center.get(center.size() - 1);
-			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
-					c.getPosXYZ().z);
-			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
-					a.getPosXYZ().z);
-			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
-					b.getPosXYZ().z);
-			AddConnection(a, b, heightMap);
-		}
-		for (int i = 1; i < center.size(); i++) {
-			EleConnector a = center.get(i - 1);
-			EleConnector b = center.get(i);
-			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
-					c.getPosXYZ().z);
-			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
-					a.getPosXYZ().z);
-			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
-					b.getPosXYZ().z);
-			if (a.groundState == GroundState.ON) {
-				if (b.groundState == GroundState.ABOVE) {
-					heightMap.put(a, 2.0);
-					heightMap.put(b, 4.0);
+	private void removeConnection(EleConnector start, EleConnector end) {
+		EleConnector a = start, b = end;
+		for (int i = 0; i < 2; i++) {
+			if (roadGraph.containsKey(a)) {
+				List<RoadNetworkEdge> edges = roadGraph.get(a);
+				for (RoadNetworkEdge edge : edges) {
+					if (edge.a == a && edge.b == b) {
+						edge.distance = Double.POSITIVE_INFINITY;
+					}
+					if (edge.a == b && edge.b == a) {
+						edge.distance = Double.POSITIVE_INFINITY;
+					}
 				}
 			}
-			if (a.groundState == GroundState.ABOVE) {
-				if (b.groundState == GroundState.ON) {
-					heightMap.put(a, 4.0);
-					heightMap.put(b, 2.0);
-				}
-			}
-			// point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, 5.0, c.getPosXYZ().z);
-			// point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, 0.0, a.getPosXYZ().z);
-			// point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, 0.0, b.getPosXYZ().z);
 		}
 	}
 
-	private void interpolateConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center,
-			EleConnector start, EleConnector end, boolean isSide) {
+	private void interpolateConnection(List<EleConnector> center, EleConnector start, EleConnector end,
+			boolean isSide) {
 		if (center.size() == 0) {
 			return;
 		}
-		// calculate length of road
-		// length will be used to calculate weights for linear interpolation
-		double length = 0;
+		removeConnection(start, end);
 		if (isSide) {
-			EleConnector before = center.get(0);
-			for (int i = 0; i < center.size(); i++) {
-				EleConnector segment = center.get(i);
-				length += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
-				before = segment;
-			}
+			addConnectionToGraph(start, center.get(0), 0);
+			addConnectionToGraph(center.get(center.size() - 1), end, 0);
 		} else {
-			EleConnector before = start;
-			for (int i = 0; i < center.size(); i++) {
-				EleConnector segment = center.get(i);
-				length += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
-				before = segment;
-			}
-			length += end.getPosXYZ().distanceToXZ(before.getPosXYZ());
+			addConnectionToGraph(start, center.get(0));
+			addConnectionToGraph(center.get(center.size() - 1), end);
 		}
-		System.out.println("length=" + length);
-
-		{
-			double pos = 0;
-			double startHeight = heightMap.get(start);
-			double endHeight = heightMap.get(end);
-			EleConnector before = isSide ? center.get(0) : start;
-			for (int i = 0; i < center.size(); i++) {
-				EleConnector segment = center.get(i);
-				pos += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
-				heightMap.put(segment, endHeight * pos / length + startHeight * (1 - pos / length));
-				before = segment;
-			}
+		for (int i = 1; i < center.size(); i++) {
+			addConnectionToGraph(center.get(i - 1), center.get(i));
 		}
 	}
 

--- a/src/main/java/org/osm2world/core/map_elevation/creation/SimpleEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/SimpleEleConstraintEnforcer.java
@@ -175,7 +175,7 @@ public final class SimpleEleConstraintEnforcer implements EleConstraintEnforcer 
 		/* TODO implement intended algorithm:
 		 * - first assign ground ele to ON
 		 * - then assign ele for ABOVE and BELOW based on min vertical distance constraints, and clearing
-		 */
+		 */ 
 
 		for (EleConnector c : connectors) {
 

--- a/src/main/java/org/osm2world/core/map_elevation/creation/SimpleInterpolatedEleConstraintEnforcer.java
+++ b/src/main/java/org/osm2world/core/map_elevation/creation/SimpleInterpolatedEleConstraintEnforcer.java
@@ -1,0 +1,464 @@
+
+package org.osm2world.core.map_elevation.creation;
+
+import static java.util.Arrays.asList;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.apache.batik.bridge.Bridge;
+import org.osm2world.core.map_data.data.MapNode;
+import org.osm2world.core.map_data.data.MapWaySegment;
+import org.osm2world.core.map_elevation.data.EleConnector;
+import org.osm2world.core.map_elevation.data.GroundState;
+import org.osm2world.core.math.VectorXYZ;
+import org.osm2world.core.world.data.NodeWorldObject;
+import org.osm2world.core.world.modules.BridgeModule;
+import org.osm2world.core.world.modules.RoadModule;
+import org.osm2world.core.world.modules.RoadModule.Road;
+import org.osm2world.core.world.modules.RoadModule.RoadConnector;
+
+/**
+ * enforcer implementation that ignores many of the constraints, but is much
+ * faster than the typical full implementation.
+ *
+ * It tries to produce an output that is "good enough" for some purposes, and is
+ * therefore a compromise between the {@link NoneEleConstraintEnforcer} and a
+ * full implementation.
+ */
+// implemented by spinachpasta
+// This enforcer configures elavation using Diffusion equation (Heat equation)
+public final class SimpleInterpolatedEleConstraintEnforcer implements EleConstraintEnforcer {
+
+	private Collection<EleConnector> connectors = new ArrayList<EleConnector>();
+
+	/**
+	 * associates each EleConnector with the {@link StiffConnectorSet} it is part of
+	 * (if any)
+	 */
+	private Map<EleConnector, StiffConnectorSet> stiffSetMap = new HashMap<EleConnector, StiffConnectorSet>();
+
+	int connectedCount = 0;
+
+	@Override
+	public void addConnectors(Iterable<EleConnector> newConnectors) {
+
+		for (EleConnector c : newConnectors) {
+			connectors.add(c);
+		}
+
+		/* connect connectors */
+
+		for (EleConnector c1 : newConnectors) {
+			for (EleConnector c2 : connectors) {
+
+				if (c1 != c2 && c1.connectsTo(c2)) {
+					requireSameEle(c1, c2);
+				}
+
+			}
+		}
+
+	}
+
+	@Override
+	public void requireSameEle(EleConnector c1, EleConnector c2) {
+
+		// SUGGEST (performance): a special case implementation would be faster
+
+		requireSameEle(asList(c1, c2));
+
+	}
+
+	@Override
+	public void requireSameEle(Iterable<EleConnector> cs) {
+
+		/* find stiff sets containing any of the affected connectors */
+
+		Set<EleConnector> looseConnectors = new HashSet<EleConnector>();
+		Set<StiffConnectorSet> existingStiffSets = new HashSet<StiffConnectorSet>();
+
+		for (EleConnector c : cs) {
+
+			StiffConnectorSet stiffSet = stiffSetMap.get(c);
+
+			if (stiffSet != null) {
+				existingStiffSets.add(stiffSet);
+			} else {
+				looseConnectors.add(c);
+			}
+
+		}
+
+		/* return if the connectors are already in a set together */
+
+		if (existingStiffSets.size() == 1 && looseConnectors.isEmpty())
+			return;
+
+		/* merge existing sets (if any) into a single set */
+
+		StiffConnectorSet commonStiffSet = null;
+
+		if (existingStiffSets.isEmpty()) {
+			commonStiffSet = new StiffConnectorSet();
+		} else {
+
+			for (StiffConnectorSet stiffSet : existingStiffSets) {
+
+				if (commonStiffSet == null) {
+					commonStiffSet = stiffSet;
+				} else {
+
+					for (EleConnector c : stiffSet) {
+						stiffSetMap.put(c, commonStiffSet);
+					}
+
+					commonStiffSet.mergeFrom(stiffSet);
+
+				}
+
+			}
+
+		}
+
+		/* add remaining (loose) connectors into the common set */
+
+		for (EleConnector c : looseConnectors) {
+
+			commonStiffSet.add(c);
+
+			stiffSetMap.put(c, commonStiffSet);
+
+		}
+
+	}
+
+	@Override
+	public void requireVerticalDistance(ConstraintType type, double distance, EleConnector upper, EleConnector lower) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void requireVerticalDistance(ConstraintType type, double distance, EleConnector upper, EleConnector base1,
+			EleConnector base2) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void requireIncline(ConstraintType type, double incline, List<EleConnector> cs) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void requireSmoothness(EleConnector from, EleConnector via, EleConnector to) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void enforceConstraints() {
+
+		/* assign elevation to stiff sets by averaging terrain elevation */
+		// TODO what for stiff sets above the ground?
+		System.out.println("DiffusionEleConstraintEnforcer:enforceConstraints");
+		for (StiffConnectorSet stiffSet : stiffSetMap.values()) {
+
+			double averageEle = 0;
+
+			for (EleConnector connector : stiffSet) {
+				averageEle += connector.getPosXYZ().y;
+			}
+
+			averageEle /= stiffSet.size();
+
+			for (EleConnector connector : stiffSet) {
+				connector.setPosXYZ(connector.pos.xyz(averageEle));
+			}
+
+		}
+		List<EleConnector> roadList = new ArrayList<EleConnector>();
+		Map<EleConnector, List<EleConnector>> roadConnectedTo = new HashMap<EleConnector, List<EleConnector>>();
+
+		Map<MapNode, EleConnector> mapNodeToEleconnector = new HashMap<MapNode, EleConnector>();
+		Map<EleConnector, Double> heightMap = new HashMap<EleConnector, Double>();
+		Map<EleConnector, Double> heightMap1 = new HashMap<EleConnector, Double>();
+
+		// initialize height map
+		for (EleConnector c : connectors) {
+			double h = 0;
+			switch (c.groundState) {
+				case ABOVE:
+					h = 5.0;
+					break;
+				case BELOW:
+					h = -5.0;
+					break;
+				default: // stay at ground elevation
+			}
+			heightMap.put(c, h);
+			heightMap1.put(c, h);
+		}
+		// connectors.forEach((c) -> {
+		for (EleConnector c : connectors) {
+			if (c.reference != null) {
+				if (c.reference instanceof MapNode) {
+					MapNode mn = (MapNode) c.reference;
+					mapNodeToEleconnector.put(mn, c);
+				}
+			} else {
+				System.out.println(c);
+			}
+		}
+		PrintWriter point_out;
+		PrintWriter point_out2;
+		try {
+			point_out = new PrintWriter(new FileOutputStream("roadpoints.csv", false));
+			point_out2 = new PrintWriter(new FileOutputStream("segmentpoints.csv", false));
+			for (EleConnector c : connectors) {
+				if (c.reference instanceof MapNode) {
+					MapNode mn = (MapNode) c.reference;
+					List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+
+					roads.forEach((road) -> {
+						MapNode start = road.getPrimaryMapElement().getStartNode();
+						MapNode end = road.getPrimaryMapElement().getEndNode();
+						if (!mapNodeToEleconnector.containsKey(start) || !mapNodeToEleconnector.containsKey(end)) {
+							System.out.println("not contained in map");
+							return;
+						}
+						EleConnector a = mapNodeToEleconnector.get(start);
+						EleConnector b = mapNodeToEleconnector.get(end);
+						AddConnection(c, b, heightMap);
+						AddConnection(c, a, heightMap);
+						// AddConnection(a, b, heightMap);
+					});
+				}
+			}
+			for (EleConnector c : connectors) {
+				if (c.reference instanceof MapNode) {
+					MapNode mn = (MapNode) c.reference;
+					List<Road> roads = RoadModule.getConnectedRoads(mn, false);// requirelanes?
+					roads.forEach((road) -> {
+						MapNode start = road.getPrimaryMapElement().getStartNode();
+						MapNode end = road.getPrimaryMapElement().getEndNode();
+						EleConnector a = mapNodeToEleconnector.get(start);
+						EleConnector b = mapNodeToEleconnector.get(end);
+						try {
+							List<EleConnector> center = road.getCenterlineEleConnectors();
+							interpolateConnection(heightMap, center, a, b, false);
+						} catch (Exception e) {
+							System.out.println("center" + e.getStackTrace());
+						}
+						try {
+							List<EleConnector> left = road.connectors.getConnectors(road.getOutlineXZ(false));
+							interpolateConnection(heightMap, left, a, b, true);
+						} catch (Exception e) {
+							// System.out.println(e.getStackTrace());
+						}
+						try {
+							List<EleConnector> right = road.connectors.getConnectors(road.getOutlineXZ(true));
+							interpolateConnection(heightMap, right, a, b, true);
+						} catch (Exception e) {
+							// System.out.println(e.getStackTrace());
+						}
+					});
+				}
+			}
+			point_out.flush();
+			point_out2.flush();
+		} catch (
+
+		FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+
+		for (EleConnector c : connectors) {
+			// TODO use clearing
+			double h = heightMap.get(c);
+			c.setPosXYZ(c.getPosXYZ().addY(h));
+		}
+
+		if (true) {
+			return;
+		}
+
+		// // });
+
+		// roadList.forEach((c) -> {
+		for (EleConnector c : roadList) {
+			VectorXYZ xyz = c.getPosXYZ();
+			// c.setPosXYZ(new VectorXYZ(xyz.x, heightMap.get(c), xyz.z));
+			c.setPosXYZ(xyz.addY(heightMap.get(c)));
+		}
+		// });
+		return;
+	}
+
+	private void DebugConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center, PrintWriter point_out,
+			EleConnector c) {
+		DebugConnection(heightMap, center, point_out, c, null, null);
+	}
+
+	private void AddConnection(EleConnector a, EleConnector b, Map<EleConnector, Double> heightMap) {
+		if (a.groundState == GroundState.ON) {
+			if (b.groundState == GroundState.ABOVE) {
+				// heightMap.put(a, 2.0);
+				heightMap.put(b, 4.0);
+				heightMap.put(a, 2.0);
+			}
+		}
+		if (a.groundState == GroundState.ABOVE) {
+			if (b.groundState == GroundState.ON) {
+				// heightMap.put(a, 4.0);
+				heightMap.put(b, 2.0);
+				heightMap.put(a, 4.0);
+			}
+		}
+	}
+
+	private void DebugConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center, PrintWriter point_out,
+			EleConnector c, @Nullable EleConnector start, @Nullable EleConnector end) {
+
+		if (start != null && center.size() > 0) {
+			EleConnector a = start;
+			EleConnector b = center.get(0);
+			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
+					c.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					a.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					b.getPosXYZ().z);
+			AddConnection(a, b, heightMap);
+		}
+		if (end != null && center.size() > 0) {
+			EleConnector a = end;
+			EleConnector b = center.get(center.size() - 1);
+			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
+					c.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					a.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					b.getPosXYZ().z);
+			AddConnection(a, b, heightMap);
+		}
+		for (int i = 1; i < center.size(); i++) {
+			EleConnector a = center.get(i - 1);
+			EleConnector b = center.get(i);
+			point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, c.groundState == GroundState.ABOVE ? 15.0 : 5.0,
+					c.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, a.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					a.getPosXYZ().z);
+			point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, b.groundState == GroundState.ABOVE ? 10.0 : 0.0,
+					b.getPosXYZ().z);
+			if (a.groundState == GroundState.ON) {
+				if (b.groundState == GroundState.ABOVE) {
+					heightMap.put(a, 2.0);
+					heightMap.put(b, 4.0);
+				}
+			}
+			if (a.groundState == GroundState.ABOVE) {
+				if (b.groundState == GroundState.ON) {
+					heightMap.put(a, 4.0);
+					heightMap.put(b, 2.0);
+				}
+			}
+			// point_out.printf("%f,%f,%f\n", c.getPosXYZ().x, 5.0, c.getPosXYZ().z);
+			// point_out.printf("%f,%f,%f\n", a.getPosXYZ().x, 0.0, a.getPosXYZ().z);
+			// point_out.printf("%f,%f,%f\n", b.getPosXYZ().x, 0.0, b.getPosXYZ().z);
+		}
+	}
+
+	private void interpolateConnection(Map<EleConnector, Double> heightMap, List<EleConnector> center,
+			EleConnector start, EleConnector end, boolean isSide) {
+		if (center.size() == 0) {
+			return;
+		}
+		// calculate length of road
+		// length will be used to calculate weights for linear interpolation
+		double length = 0;
+		if (isSide) {
+			EleConnector before = center.get(0);
+			for (int i = 0; i < center.size(); i++) {
+				EleConnector segment = center.get(i);
+				length += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
+				before = segment;
+			}
+		} else {
+			EleConnector before = start;
+			for (int i = 0; i < center.size(); i++) {
+				EleConnector segment = center.get(i);
+				length += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
+				before = segment;
+			}
+			length += end.getPosXYZ().distanceToXZ(before.getPosXYZ());
+		}
+		System.out.println("length=" + length);
+
+		{
+			double pos = 0;
+			double startHeight = heightMap.get(start);
+			double endHeight = heightMap.get(end);
+			EleConnector before = isSide ? center.get(0) : start;
+			for (int i = 0; i < center.size(); i++) {
+				EleConnector segment = center.get(i);
+				pos += segment.getPosXYZ().distanceToXZ(before.getPosXYZ());
+				heightMap.put(segment, endHeight * pos / length + startHeight * (1 - pos / length));
+				before = segment;
+			}
+		}
+	}
+
+	/**
+	 * a set of connectors that are required to have the same elevation TODO or a
+	 * precise vertical offset
+	 */
+	private static class StiffConnectorSet implements Iterable<EleConnector> {
+
+		// TODO maybe look for a more efficient set implementation
+		private Set<EleConnector> connectors = new HashSet<EleConnector>();
+
+		/**
+		 * adds a connector to this set, requiring it to be at the set's reference
+		 * elevation
+		 */
+		public void add(EleConnector connector) {
+			connectors.add(connector);
+		}
+
+		/**
+		 * combines this set with another, and makes the other set unusable. This set
+		 * will contain all {@link EleConnector}s from the other set afterwards.
+		 */
+		public void mergeFrom(StiffConnectorSet otherSet) {
+
+			connectors.addAll(otherSet.connectors);
+
+			// make sure that the other set cannot be used anymore
+			otherSet.connectors = null;
+
+		}
+
+		public double size() {
+			return connectors.size();
+		}
+
+		@Override
+		public Iterator<EleConnector> iterator() {
+			return connectors.iterator();
+		}
+
+	}
+
+}

--- a/src/main/java/org/osm2world/core/world/network/AbstractNetworkWaySegmentWorldObject.java
+++ b/src/main/java/org/osm2world/core/world/network/AbstractNetworkWaySegmentWorldObject.java
@@ -58,7 +58,7 @@ public abstract class AbstractNetworkWaySegmentWorldObject implements NetworkWay
 	private VectorXZ endCutCenter = null;
 	private VectorXZ endCutRight = null;
 
-	protected EleConnectorGroup connectors;
+	public EleConnectorGroup connectors;
 
 	protected List<AttachmentConnector> attachmentConnectorList = emptyList();
 

--- a/src/main/java/org/osm2world/core/world/network/AbstractNetworkWaySegmentWorldObject.java
+++ b/src/main/java/org/osm2world/core/world/network/AbstractNetworkWaySegmentWorldObject.java
@@ -448,7 +448,7 @@ public abstract class AbstractNetworkWaySegmentWorldObject implements NetworkWay
 
 	}
 
-	protected List<EleConnector> getCenterlineEleConnectors() {
+	public List<EleConnector> getCenterlineEleConnectors() {
 
 		if (isBroken()) return emptyList();
 


### PR DESCRIPTION
- Smooth elevation of road based on diffusion equation
- Performance improvement of EleConstraintEnforcer.addConnectors using axis aligned boundary boxes

<img width="767" alt="Screen Shot 2021-06-06 at 14 51 35" src="https://user-images.githubusercontent.com/49642352/121126475-2d2a5a80-c863-11eb-978e-6459097a9068.png">

Command Usage
```bash
/osm2world.sh -i ~/Downloads/map.osm -o ./test.obj --config example_config.properties
```

example_config.properties
```yaml
! This is an example for an OSM2World (http://osm2world.org/) config file.
! It is not used by default. If you want to use a config file, try the
! "--config <filename>" option on the command line when starting OSM2World.
! For more options and documentation, see the OpenStreetMap wiki:
! http://wiki.osm.org/OSM2World/Configuration_file

# a directory containing raw SRTM elevation data,
# which can be obtained from http://dds.cr.usgs.gov/srtm/version2_1/SRTM3/
# If this is not available, terrain calculation is disabled.
# srtmDir = srtm

# background color or image for PNG output
backgroundColor = #000000
# backgroundImage = textures/background.png

# tree density in forests
treesPerSquareMeter = 0.001

# tree heights
defaultTreeHeight = 10.0
defaultTreeHeightForest = 20.0

# sets the color of "empty" terrain. See Materials.java for other materials.
material_TERRAIN_DEFAULT_color = #FFFFFF

# sets a texture for building walls.
# material_BUILDING_DEFAULT_texture_file = textures/plaster.png
# material_BUILDING_DEFAULT_texture_width = 2.5
# material_BUILDING_DEFAULT_texture_height = 2.5
# material_BUILDING_DEFAULT_texture_colorable = true

# enable (true) or disable (false) parsing of building color and material tags
useBuildingColors = true

# enable (true) or disable (false) replacing geometry with textured billboards
useBillboards = true

# enable (true) or disable (false) rendering of world objects below the ground
renderUnderground = true

# true prevents the PNG export from buffering primitives. This reduces RAM usage, but can increase rendering time.
forceUnbufferedPNGRendering = false

# maximum size for each dimension of the OpenGL canvas used for PNG output.
# If this is lower than the width or height of the requested png, performance suffers.
# Increase it if your graphics hardware is capable of handling larger sizes.
canvasLimit = 1024
eleConstraintEnforcer=DiffusionEleConstraintEnforcer

```