### PR TITLE
Fix NullPointerException for non-absolute output paths

### DIFF
--- a/src/main/java/org/osm2world/console/Output.java
+++ b/src/main/java/org/osm2world/console/Output.java
@@ -184,7 +184,7 @@ public final class Output {
 
 			for (File outputFile : args.getOutput()) {
 
-				outputFile.getParentFile().mkdirs();
+				outputFile.getAbsoluteFile().getParentFile().mkdirs();
 
 				OutputMode outputMode = CLIArgumentsUtil.getOutputMode(outputFile);
 


### PR DESCRIPTION
The exception occurred when using --output tileexample.pov (rather than --output ./tileexample.pov) on the command line.