### PR TITLE
change boolean from primative to object

### DIFF
--- a/src/main/java/org/osm2world/core/target/gltf/data/GltfMaterial.java
+++ b/src/main/java/org/osm2world/core/target/gltf/data/GltfMaterial.java
@@ -44,7 +44,7 @@ public class GltfMaterial {
 	public @Nullable float[] emissiveFactor;
 	public @Nullable String alphaMode;
 	public @Nullable Float alphaCutoff;
-	public @Nullable boolean doubleSided;
+	public @Nullable Boolean doubleSided;
 
 	public @Nullable String name;
 	public @Nullable Map<String, Object> extensions;


### PR DESCRIPTION
objects, not primatives, can be Nullable so there are runtime errors sometimes when exporting to gltf