### PR TITLE
Cesium 3dTtiles generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,11 @@ nbactions.xml
 nbbuild.xml
 nb-configuration.xml
 
+# Vscode
+.vscode/
+
 # Miscellaneous
 *~
 *.swp
+*.tileset.json
 .DS_Store

--- a/build-adds/tiles-to-glb.sh
+++ b/build-adds/tiles-to-glb.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Usage ./tiles-to-glb.sh /path/to/tiles
+
+BASE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
+BIN="java -jar $BASE_DIR/target/osm2world-0.4.0-SNAPSHOT.jar"
+
+TILES_ROOT=${1%/}
+
+echo "Convert tiles from $TILES_ROOT"
+echo $BASE_DIR
+
+mkdir -p "$TILES_ROOT/tiles"
+
+for tile_p in $(find $TILES_ROOT -iname '*.osm'); do
+    #cut prefix
+    tile_sfx=${tile_p#"$TILES_ROOT/"}
+    #cut suffix
+    tile=${tile_sfx%".osm"}
+
+    z=${tile%%/*}
+    xy=${tile#*/}
+    x=${xy%%/*}
+    y=${xy#*/}
+
+if [ -f "$TILES_ROOT/$z/$x/$y.osm" ]; then
+    echo $tile $z $x $y
+
+    cmd="$BIN --input $TILES_ROOT/$z/$x/$y.osm --tile $z/$x/$y --output $TILES_ROOT/tiles/${z}_${x}_${y}.glb"
+    $cmd > /dev/null 2>&1
+fi
+
+done

--- a/src/main/java/org/cesiumjs/LICENSE.md
+++ b/src/main/java/org/cesiumjs/LICENSE.md
@@ -1,0 +1,826 @@
+Copyright 2011-2017 Cesium Contributors
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2011-2017 Cesium Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+Patents 9153063 and 9865085
+
+Third-Party Code
+================
+
+Cesium includes the following third-party code.
+
+### Sean O'Neil
+
+http://sponeil.net/
+
+> Copyright (c) 2000-2005, Sean O'Neil (s_p_oneil@hotmail.com)
+>
+> All rights reserved.
+>
+> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+>
+> * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+> * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+> * Neither the name of the project nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+###  Grauw Uri utilities
+
+http://hg.grauw.nl/grauw-lib
+
+> Laurens Holst (http://www.grauw.nl/)
+>
+> Copyright 2012 Laurens Holst
+>
+> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+>
+> http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+### when.js
+
+https://github.com/cujojs/when
+
+>  Licensed under the MIT License at:
+>  http://www.opensource.org/licenses/mit-license.php
+>
+>  MIT License (c) copyright B Cavalier &amp; J Hann
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### zip.js
+
+https://github.com/gildas-lormeau/zip.js
+
+>  Copyright (c) 2013 Gildas Lormeau. All rights reserved.
+>
+>  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+>
+>  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+>
+>  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+>
+>  3. The names of the authors may not be used to endorse or promote products derived from this software without specific prior written permission.
+>
+>  THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### Autolinker.js
+
+https://github.com/gregjacobs/Autolinker.js
+
+The MIT License (MIT)
+
+> Copyright (c) 2015 Gregory Jacobs (http://greg-jacobs.com)
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### tween.js
+
+https://github.com/sole/tween.js
+
+> Copyright (c) 2010-2012 Tween.js authors.
+>
+> Easing equations Copyright (c) 2001 Robert Penner http://robertpenner.com/easing/
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### php.js
+
+https://github.com/kvz/phpjs
+
+> php.js is copyright 2013 Kevin van Zonneveld.
+>
+> Portions copyright Brett Zamir (http://brett-zamir.me), Kevin van Zonneveld (http://kevin.vanzonneveld.net), Onno Marsman, Theriault, Michael White (http://getsprink.com), Waldo Malqui Silva, Paulo Freitas, Jack, Jonas Raoni Soares Silva (http://www.jsfromhell.com), Philip Peterson, Legaev Andrey, Ates Goral (http://magnetiq.com), Alex, Ratheous, Martijn Wieringa, Rafa? Kukawski (http://blog.kukawski.pl), lmeyrick (https://sourceforge.net/projects/bcmath-js/), Nate, Philippe Baumann, Enrique Gonzalez, Webtoolkit.info (http://www.webtoolkit.info/), Carlos R. L. Rodrigues (http://www.jsfromhell.com), Ash Searle (http://hexmen.com/blog/), Jani Hartikainen, travc, Ole Vrijenhoek, Erkekjetter, Michael Grier, Rafa? Kukawski (http://kukawski.pl), Johnny Mast (http://www.phpvrouwen.nl), T.Wild, d3x, http://stackoverflow.com/questions/57803/how-to-convert-decimal-to-hex-in-javascript, Rafa? Kukawski (http://blog.kukawski.pl/), stag019, pilus, WebDevHobo (http://webdevhobo.blogspot.com/), marrtins, GeekFG (http://geekf  blogspot.com), Andrea Giammarchi (http://webreflection.blogspot.com), Arpad Ray (mailto:arpad@php.net), gorthaur, Paul Smith, Tim de Koning (http://www.kingsquare.nl), Joris, Oleg Eremeev, Steve Hilder, majak, gettimeofday, KELAN, Josh Fraser (http://onlineaspect.com/2007/06/08/auto-detect-a-time-zone-with-javascript/), Marc Palau, Martin (http://www.erlenwiese.de/), Breaking Par Consulting Inc (http://www.breakingpar.com/bkp/home.nsf/0/87256B280015193F87256CFB006C45F7), Chris, Mirek Slugen, saulius, Alfonso Jimenez (http://www.alfonsojimenez.com), Diplom@t (http://difane.com/), felix, Mailfaker (http://www.weedem.fr/), Tyler Akins (http://rumkin.com), Caio Ariede (http://caioariede.com), Robin, Kankrelune (http://www.webfaktory.info/), Karol Kowalski, Imgen Tata (http://www.myipdf.com/), mdsjack (http://www.mdsjack.bo.it), Dreamer, Felix Geisendoerfer (http://www.debuggable.com/felix), Lars Fischer, AJ, David, Aman Gupta, Michael White, Public Domain (http://www.json.org/json2.js), Steven Levithan (http://b  g.stevenlevithan.com), Sakimori, Pellentesque Malesuada, Thunder.m, Dj (http://phpjs.org/functions/htmlentities:425#comment_134018), Steve Clay, David James, Francois, class_exists, nobbler, T. Wild, Itsacon (http://www.itsacon.net/), date, Ole Vrijenhoek (http://www.nervous.nl/), Fox, Raphael (Ao RUDLER), Marco, noname, Mateusz "loonquawl" Zalega, Frank Forte, Arno, ger, mktime, john (http://www.jd-tech.net), Nick Kolosov (http://sammy.ru), marc andreu, Scott Cariss, Douglas Crockford (http://javascript.crockford.com), madipta, Slawomir Kaniecki, ReverseSyntax, Nathan, Alex Wilson, kenneth, Bayron Guevara, Adam Wallner (http://web2.bitbaro.hu/), paulo kuong, jmweb, Lincoln Ramsay, djmix, Pyerre, Jon Hohle, Thiago Mata (http://thiagomata.blog.com), lmeyrick (https://sourceforge.net/projects/bcmath-js/this.), Linuxworld, duncan, Gilbert, Sanjoy Roy, Shingo, sankai, Oskar Larsson H?gfeldt (http://oskar-lh.name/), Denny Wardhana, 0m3r, Everlasto, Subhasis Deb, josh, jd, Pier Paolo Ramon (http://www.mastersoup.c  /), P, merabi, Soren Hansen, Eugene Bulkin (http://doubleaw.com/), Der Simon (http://innerdom.sourceforge.net/), echo is bad, Ozh, XoraX (http://www.xorax.info), EdorFaus, JB, J A R, Marc Jansen, Francesco, LH, Stoyan Kyosev (http://www.svest.org/), nord_ua, omid (http://phpjs.org/functions/380:380#comment_137122), Brad Touesnard, MeEtc (http://yass.meetcweb.com), Peter-Paul Koch (http://www.quirksmode.org/js/beat.html), Olivier Louvignes (http://mg-crea.com/), T0bsn, Tim Wiel, Bryan Elliott, Jalal Berrami, Martin, JT, David Randall, Thomas Beaucourt (http://www.webapp.fr), taith, vlado houba, Pierre-Luc Paour, Kristof Coomans (SCK-CEN Belgian Nucleair Research Centre), Martin Pool, Kirk Strobeck, Rick Waldron, Brant Messenger (http://www.brantmessenger.com/), Devan Penner-Woelk, Saulo Vallory, Wagner B. Soares, Artur Tchernychev, Valentina De Rosa, Jason Wong (http://carrot.org/), Christoph, Daniel Esteban, strftime, Mick@el, rezna, Simon Willison (http://simonwillison.net), Anton Ongson, Gabriel Paderni, M rco van Oort, penutbutterjelly, Philipp Lenssen, Bjorn Roesbeke (http://www.bjornroesbeke.be/), Bug?, Eric Nagel, Tomasz Wesolowski, Evertjan Garretsen, Bobby Drake, Blues (http://tech.bluesmoon.info/), Luke Godfrey, Pul, uestla, Alan C, Ulrich, Rafal Kukawski, Yves Sucaet, sowberry, Norman "zEh" Fuchs, hitwork, Zahlii, johnrembo, Nick Callen, Steven Levithan (stevenlevithan.com), ejsanders, Scott Baker, Brian Tafoya (http://www.premasolutions.com/), Philippe Jausions (http://pear.php.net/user/jausions), Aidan Lister (http://aidanlister.com/), Rob, e-mike, HKM, ChaosNo1, metjay, strcasecmp, strcmp, Taras Bogach, jpfle, Alexander Ermolaev (http://snippets.dzone.com/user/AlexanderErmolaev), DxGx, kilops, Orlando, dptr1988, Le Torbi, James (http://www.james-bell.co.uk/), Pedro Tainha (http://www.pedrotainha.com), James, Arnout Kazemier (http://www.3rd-Eden.com), Chris McMacken, gabriel paderni, Yannoo, FGFEmperor, baris ozdil, Tod Gentille, Greg Frazier, jakes, 3D-GRAF, Allan Jensen (http://www.winternet.no), Ho ard Yeend, Benjamin Lupton, davook, daniel airton wermann (http://wermann.com.br), Atli T??r, Maximusya, Ryan W Tenney (http://ryan.10e.us), Alexander M Beedie, fearphage (http://http/my.opera.com/fearphage/), Nathan Sepulveda, Victor, Matteo, Billy, stensi, Cord, Manish, T.J. Leahy, Riddler (http://www.frontierwebdev.com/), Rafa? Kukawski, FremyCompany, Matt Bradley, Tim de Koning, Luis Salazar (http://www.freaky-media.com/), Diogo Resende, Rival, Andrej Pavlovic, Garagoth, Le Torbi (http://www.letorbi.de/), Dino, Josep Sanz (http://www.ws3.es/), rem, Russell Walker (http://www.nbill.co.uk/), Jamie Beck (http://www.terabit.ca/), setcookie, Michael, YUI Library: http://developer.yahoo.com/yui/docs/YAHOO.util.DateLocale.html, Blues at http://hacks.bluesmoon.info/strftime/strftime.js, Ben (http://benblume.co.uk/), DtTvB (http://dt.in.th/2008-09-16.string-length-in-bytes.html), Andreas, William, meo, incidence, Cagri Ekin, Amirouche, Amir Habibi (http://www.residence-mixte.com/), Luke Smith (http://lucassmith.na  ), Kheang Hok Chin (http://www.distantia.ca/), Jay Klehr, Lorenzo Pisani, Tony, Yen-Wei Liu, Greenseed, mk.keck, Leslie Hoare, dude, booeyOH, Ben Bryan
+>
+> Licensed under the MIT (MIT-LICENSE.txt) license.
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL KEVIN VAN ZONNEVELD BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OROTHER DEALINGS IN THE SOFTWARE.
+
+### fontmetrics.js
+
+https://github.com/Pomax/fontmetrics.js
+
+> Copyright (C) 2011 by Mike "Pomax" Kamermans
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### almond
+
+https://github.com/jrburke/almond
+
+> Copyright (c) 2010-2011, The Dojo Foundation
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### RequireJS
+
+https://github.com/jrburke/requirejs
+
+> Copyright (c) 2010-2015, The Dojo Foundation
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### Knockout
+
+http://knockoutjs.com/
+
+> (c) The Knockout.js team - http://knockoutjs.com/
+> License: MIT (http://www.opensource.org/licenses/mit-license.php)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### Knockout ES5 plugin
+
+https://github.com/SteveSanderson/knockout-es5
+
+> Copyright (c) Steve Sanderson
+> MIT license
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### topojson
+
+https://github.com/mbostock/topojson
+
+> Copyright (c) 2012, Michael Bostock
+> All rights reserved.
+>
+> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+>
+> * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+>
+> * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+>
+> * The name Michael Bostock may not be used to endorse or promote products derived from this software without specific prior written permission.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### mersenne-twister.js
+
+https://gist.github.com/banksean/300494
+
+> Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+> All rights reserved.
+>
+> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+>
+> 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+>
+> 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+>
+> 3. The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### NVIDIA GameWorks Graphics Samples
+
+https://github.com/NVIDIAGameWorks/GraphicsSamples
+
+> Copyright 2016 NVIDIA Corporation
+>
+> BY DOWNLOADING THE SOFTWARE AND OTHER AVAILABLE MATERIALS, YOU  ("DEVELOPER") AGREE TO BE BOUND BY THE FOLLOWING TERMS AND CONDITIONS
+>
+> The materials available for download to Developers may include software in both sample source ("Source Code") and object code ("Object Code") versions, documentation ("Documentation"), certain art work ("Art Assets") and other materials (collectively, these materials referred to herein as "Materials").  Except as expressly indicated herein, all terms and conditions of this Agreement apply to all of the Materials.
+>
+> Except as expressly set forth herein, NVIDIA owns all of the Materials and makes them available to Developer only under the terms and conditions set forth in this Agreement.
+>
+> License:  Subject to the terms of this Agreement, NVIDIA hereby grants to Developer a royalty-free, non-exclusive license to possess and to use the Materials.  The following terms apply to the specified type of Material:
+>
+> Source Code:  Developer shall have the right to modify and create derivative works with the Source Code.  Developer shall own any derivative works ("Derivatives") it creates to the Source Code, provided that Developer uses the Materials in accordance with the terms of this Agreement.  Developer may distribute the Derivatives, provided that all NVIDIA copyright notices and trademarks are used properly and the Derivatives include the following statement: "This software contains source code provided by NVIDIA Corporation."
+>
+> Object Code:  Developer agrees not to disassemble, decompile or reverse engineer the Object Code versions of any of the Materials.  Developer acknowledges that certain of the Materials provided in Object Code version may contain third party components that may be subject to restrictions, and expressly agrees not to attempt to modify or distribute such Materials without first receiving consent from NVIDIA.
+>
+> Art Assets:  Developer shall have the right to modify and create Derivatives of the Art Assets, but may not distribute any of the Art Assets or Derivatives created therefrom without NVIDIA's prior written consent.
+>
+> Government End Users: If you are acquiring the Software on behalf of any unit or agency of the United States Government, the following provisions apply. The Government agrees the Software and documentation were developed at private expense and are provided with "RESTRICTED RIGHTS". Use, duplication, or disclosure by the Government is subject to restrictions as set forth in DFARS 227.7202-1(a) and 227.7202-3(a) (1995), DFARS 252.227-7013(c)(1)(ii) (Oct 1988), FAR 12.212(a)(1995), FAR 52.227-19, (June 1987) or FAR 52.227-14(ALT III) (June 1987),as amended from time to time. In the event that this License, or any part thereof, is deemed inconsistent with the minimum rights identified in the Restricted Rights provisions, the minimum rights shall prevail.
+> No Other License. No rights or licenses are granted by NVIDIA under this License, expressly or by implication, with respect to any proprietary information or patent, copyright, trade secret or other intellectual property right owned or controlled by NVIDIA, except as expressly provided in this License.
+> Term:  This License is effective until terminated.  NVIDIA may terminate this Agreement (and with it, all of Developer's right to the Materials) immediately upon written notice (which may include email) to Developer, with or without cause.
+>
+> Support:  NVIDIA has no obligation to support or to continue providing or updating any of the Materials.
+>
+> No Warranty:  THE SOFTWARE AND ANY OTHER MATERIALS PROVIDED BY NVIDIA TO DEVELOPER HEREUNDER ARE PROVIDED "AS IS."  NVIDIA DISCLAIMS ALL WARRANTIES, EXPRESS, IMPLIED OR STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+>
+> LIMITATION OF LIABILITY:  NVIDIA SHALL NOT BE LIABLE TO DEVELOPER, DEVELOPER'S CUSTOMERS, OR ANY OTHER PERSON OR ENTITY CLAIMING THROUGH OR UNDER DEVELOPER FOR ANY LOSS OF PROFITS, INCOME, SAVINGS, OR ANY OTHER CONSEQUENTIAL, INCIDENTAL, SPECIAL, PUNITIVE, DIRECT OR INDIRECT DAMAGES (WHETHER IN AN ACTION IN CONTRACT, TORT OR BASED ON A WARRANTY), EVEN IF NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  THESE LIMITATIONS SHALL APPLY NOTWITHSTANDING ANY FAILURE OF THE ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.  IN NO EVENT SHALL NVIDIA'S AGGREGATE LIABILITY TO DEVELOPER OR ANY OTHER PERSON OR ENTITY CLAIMING THROUGH OR UNDER DEVELOPER EXCEED THE AMOUNT OF MONEY ACTUALLY PAID BY DEVELOPER TO NVIDIA FOR THE SOFTWARE OR ANY OTHER MATERIALS.
+
+### NoSleep.js
+
+https://github.com/richtr/NoSleep.js
+
+> NoSleep.js v0.5.0 - git.io/vfn01
+> Rich Tibbett
+> MIT license
+
+### jsep
+
+https://github.com/soney/jsep
+
+> Copyright (c) 2013 Stephen Oney, http://jsep.from.so/
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### earcut
+
+https://github.com/mapbox/earcut
+
+>Copyright (c) 2016, Mapbox
+>
+>Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+>
+>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+### kdbush
+
+https://github.com/mourner/kdbush
+
+> Copyright (c) 2016, Vladimir Agafonkin
+>
+>Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+>
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+### crunch
+
+https://github.com/BinomialLLC/crunch
+
+>crunch/crnlib uses the ZLIB license:
+>http://opensource.org/licenses/Zlib
+>
+>Copyright (c) 2010-2016 Richard Geldreich, Jr. and Binomial LLC
+>
+>This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+>
+>Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+>
+>1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+>
+>2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+>
+>3. This notice may not be removed or altered from any source distribution.
+
+### crunch_lib.cpp
+
+https://github.com/Apress/html5-game-dev-insights/blob/master/jones_ch21/crunch_webgl/crunch_js/crunch_lib.cpp
+
+>Copyright (c) 2013, Evan Parker, Brandon Jones. All rights reserved.
+>
+>Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+>
+>  * Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+>  * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+>
+>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+### texture-tester
+
+https://github.com/toji/texture-tester
+
+>Copyright (c) 2014, Brandon Jones. All rights reserved.
+>
+>Redistribution and use in source and binary forms, with or without modification,
+>are permitted provided that the following conditions are met:
+>
+>* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+>* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+>
+>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### pako
+
+https://github.com/nodeca/pako
+
+>(The MIT License)
+>
+>Copyright (C) 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn
+>
+>Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+>
+>The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+>
+>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+### protobuf
+
+https://github.com/dcodeIO/ProtoBuf.js
+
+>Copyright (c) 2016, Daniel Wirtz  All rights reserved.
+>
+>Redistribution and use in source and binary forms, with or without
+>modification, are permitted provided that the following conditions are
+>met:
+>
+>* Redistributions of source code must retain the above copyright
+>  notice, this list of conditions and the following disclaimer.
+>* Redistributions in binary form must reproduce the above copyright
+>  notice, this list of conditions and the following disclaimer in the
+>  documentation and/or other materials provided with the distribution.
+>* Neither the name of its author, nor the names of its contributors
+>  may be used to endorse or promote products derived from this software
+>  without specific prior written permission.
+>
+>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+>"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+>LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+>A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+>OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+>SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+>LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+>DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+>THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+>(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+>OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### gltf-WebGL-PBR
+
+https://github.com/KhronosGroup/glTF-WebGL-PBR
+
+>The MIT License
+>
+>Copyright (c) 2016-2017 Mohamad Moneimne and Contributors
+>
+>Permission is hereby granted, free of charge, to any person obtaining
+>a copy of this software and associated documentation files (the "Software"),
+>to deal in the Software without restriction, including without limitation the
+>rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+>sell copies of the Software, and to permit persons to whom the Software is
+>furnished to do so, subject to the following conditions:
+>
+>The above copyright notice and this permission notice shall be included in
+>all copies or substantial portions of the Software.
+>
+>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+>INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+>PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+>HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+>CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+>OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Tests
+=====
+
+The Cesium tests use the following third-party libraries and data.
+
+### Jasmine
+
+http://jasmine.github.io/
+
+Copyright (c) 2008-2014 Pivotal Labs
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Cesium Documentation
+====================
+
+The Cesium documentation files include the following third-party content.
+
+### Source Sans Pro (Font)
+
+Source® Sans Pro, Adobe's first open source typeface family, was designed by Paul D. Hunt. It is a sans serif typeface intended to work well in user interfaces.
+
+[SIL Open Font License, 1.1](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL) ([text](http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=OFL_plaintext&filename=OFL.txt))
+
+
+Example Applications
+====================
+
+The Cesium example applications include the following third-party libraries and data.
+
+### Dojo Toolkit
+
+http://dojotoolkit.org/
+
+> Copyright (c) 2005-2015, The Dojo Foundation
+>
+> All rights reserved.
+>
+> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+>
+>   * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+>   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+>   * Neither the name of the Dojo Foundation nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### CodeMirror
+
+http://codemirror.net/
+
+> Copyright (C) 2014 by Marijn Haverbeke <marijnh@gmail.com> and others
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+>
+> Please note that some subdirectories of the CodeMirror distribution include their own LICENSE files, and are released under different licences.
+
+### JSHint
+
+http://www.jshint.com/
+
+> JSHint, by JSHint Community.
+>
+> Licensed under the same slightly modified MIT license that JSLint is. It stops evil-doers everywhere.
+>
+> JSHint is a derivative work of JSLint:
+>
+> Copyright (c) 2002 Douglas Crockford (www.JSLint.com)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> The Software shall be used for Good, not Evil.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. JSHint was forked from the 2010-12-16 edition of JSLint.
+
+### Public domain data from Natural Earth
+
+Free vector and raster map data @ naturalearthdata.com
+
+Terms of use: http://www.naturalearthdata.com/about/terms-of-use/
+
+### Data from JHT's Planetary Pixel Emporium
+
+Copyright (c) by James Hastings-Trew
+
+http://planetpixelemporium.com/
+
+Copyright Information:  http://planetpixelemporium.com/planets.html
+
+### Sky box images from NASA
+
+http://maps.jpl.nasa.gov/stars.html
+
+http://svs.gsfc.nasa.gov/vis/a000000/a003500/a003572/
+
+Terms of use: http://www.nasa.gov/audience/formedia/features/MP_Photo_Guidelines.html
+
+### Some vector icons from (or inspired by) Raphaël JS
+
+http://raphaeljs.com/icons/
+
+http://raphaeljs.com/license.html
+
+### Mouse and gesture vector icons made by Freepik from Flaticon.com
+
+http://www.flaticon.com/authors/freepik
+
+### Maki icon set from Mapbox
+
+https://www.mapbox.com/maki/
+
+https://github.com/mapbox/maki
+
+### Big Buck Bunny trailer
+
+Creative Commons Attribution 3.0
+(c) copyright 2008, Blender Foundation
+www.bigbuckbunny.org
+
+### population909500.json ###
+
+https://github.com/dataarts/webgl-globe
+
+> Copyright 2011 Google Data Arts Team
+>
+> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+>
+>     http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+### Wooden Watch Tower ###
+
+Creative Commons Attribution 3.0
+(c) copyright 2012, Dennis Haupt
+http://www.blendswap.com/blends/view/61653
+
+### GitHub logo
+
+https://github.com/logos
+
+### Font Awesome Icon
+
+Font Awesome by Dave Gandy - http://fontawesome.io

--- a/src/main/java/org/cesiumjs/WGS84Util.java
+++ b/src/main/java/org/cesiumjs/WGS84Util.java
@@ -1,0 +1,80 @@
+package org.cesiumjs;
+
+import org.osm2world.core.map_data.creation.LatLon;
+import org.osm2world.core.math.VectorXYZ;
+
+/**
+ * This code is adoptation of Cesiumjs code.
+ * See LICENSE.md
+ * */
+public class WGS84Util {
+
+	private static final double WGS84_A = 6378137.0;
+	private static final double WGS84_B = 6356752.3142451793;
+
+	private static final VectorXYZ oneOverRadiiSquared = new VectorXYZ(
+			1.0 / (WGS84_A * WGS84_A), 
+			1.0 / (WGS84_A * WGS84_A), 
+			1.0 / (WGS84_B * WGS84_B));
+	
+	private static final VectorXYZ wgs84RadiiSquared = 
+			new VectorXYZ(WGS84_A * WGS84_A, WGS84_A * WGS84_A, WGS84_B * WGS84_B);
+	
+	public static VectorXYZ cartesianFromLatLon(LatLon origin, double height) {
+		double latitude = Math.toRadians(origin.lat);
+		double longitude = Math.toRadians(origin.lon);
+		VectorXYZ radiiSquared = wgs84RadiiSquared;
+
+        double cosLatitude = Math.cos(latitude);
+        VectorXYZ scratchN = new VectorXYZ(
+        		cosLatitude * Math.cos(longitude), 
+        		cosLatitude * Math.sin(longitude),
+        		Math.sin(latitude));
+        
+        scratchN = scratchN.normalize();
+
+        VectorXYZ scratchK = mulByComponents(radiiSquared, scratchN);
+        double gamma = Math.sqrt(scratchN.dot(scratchK));
+        scratchK = scratchK.mult(1.0 / gamma);
+        scratchN = scratchN.mult(height);
+
+        return scratchK.add(scratchN);
+	}
+	
+	public static double[] eastNorthUpToFixedFrame(VectorXYZ cartesian) {
+		
+		VectorXYZ normal = geodeticSurfaceNormal(cartesian);
+		VectorXYZ tangent = new VectorXYZ(-cartesian.y, cartesian.x, 0.0).normalize();
+		VectorXYZ bitangent = normal.cross(tangent);
+		
+		// Matrix 4x4 by columns 
+		return new double[] {
+				tangent.x,
+		        tangent.y,
+		        tangent.z,
+		        0.0,
+		        bitangent.x,
+		        bitangent.y,
+		        bitangent.z,
+		        0.0,
+		        normal.x,
+		        normal.y,
+		        normal.z,
+		        0.0,
+		        cartesian.x,
+		        cartesian.y,
+		        cartesian.z,
+		        1.0
+		};
+	}
+	
+	public static VectorXYZ geodeticSurfaceNormal(VectorXYZ cartesian) {
+		VectorXYZ mulByComponents = mulByComponents(cartesian, oneOverRadiiSquared);
+		return mulByComponents.normalize();
+	}
+	
+	public static VectorXYZ mulByComponents(VectorXYZ a, VectorXYZ b) {
+		return new VectorXYZ(a.x * b.x, a.y * b.y, a.z * b.z);
+	}
+	
+}

--- a/src/main/java/org/osm2world/console/Output.java
+++ b/src/main/java/org/osm2world/console/Output.java
@@ -1,11 +1,11 @@
 package org.osm2world.console;
 
-import static java.time.Instant.now;
-import static java.util.Collections.singletonList;
-import static java.util.Map.entry;
-import static java.util.stream.Collectors.toList;
+import static java.time.Instant.*;
+import static java.util.Collections.*;
+import static java.util.Map.*;
+import static java.util.stream.Collectors.*;
 import static org.osm2world.core.ConversionFacade.Phase.*;
-import static org.osm2world.core.math.AxisAlignedRectangleXZ.bbox;
+import static org.osm2world.core.math.AxisAlignedRectangleXZ.*;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -32,10 +32,21 @@ import org.osm2world.core.conversion.ConversionLog;
 import org.osm2world.core.map_data.creation.LatLonBounds;
 import org.osm2world.core.map_data.creation.MapProjection;
 import org.osm2world.core.map_data.data.MapMetadata;
-import org.osm2world.core.map_elevation.creation.*;
+import org.osm2world.core.map_elevation.creation.BridgeTunnelEleCalculator;
+import org.osm2world.core.map_elevation.creation.ConstraintEleCalculator;
+import org.osm2world.core.map_elevation.creation.EleTagEleCalculator;
+import org.osm2world.core.map_elevation.creation.LeastSquaresInterpolator;
+import org.osm2world.core.map_elevation.creation.NaturalNeighborInterpolator;
+import org.osm2world.core.map_elevation.creation.NoOpEleCalculator;
+import org.osm2world.core.map_elevation.creation.SimpleEleConstraintEnforcer;
+import org.osm2world.core.map_elevation.creation.ZeroInterpolator;
 import org.osm2world.core.math.AxisAlignedRectangleXZ;
 import org.osm2world.core.math.VectorXYZ;
-import org.osm2world.core.osm.creation.*;
+import org.osm2world.core.osm.creation.GeodeskReader;
+import org.osm2world.core.osm.creation.MbtilesReader;
+import org.osm2world.core.osm.creation.OSMDataReader;
+import org.osm2world.core.osm.creation.OSMFileReader;
+import org.osm2world.core.osm.creation.OverpassReader;
 import org.osm2world.core.target.TargetUtil;
 import org.osm2world.core.target.TargetUtil.Compression;
 import org.osm2world.core.target.common.rendering.Camera;
@@ -230,7 +241,7 @@ public final class Output {
 							? GltfTarget.GltfFlavor.GLB : GltfTarget.GltfFlavor.GLTF;
 					Compression compression = EnumSet.of(OutputMode.GLTF_GZ, OutputMode.GLB_GZ).contains(outputMode)
 							? Compression.GZ : Compression.NONE;
-					GltfTarget gltfTarget = new GltfTarget(outputFile, gltfFlavor, compression, bounds);
+					GltfTarget gltfTarget = new GltfTarget(outputFile, gltfFlavor, compression, results.getMapProjection(), bounds);
 					gltfTarget.setConfiguration(config);
 					boolean underground = config.getBoolean("renderUnderground", true);
 					TargetUtil.renderWorldObjects(gltfTarget, results.getMapData(), underground);

--- a/src/main/java/org/osm2world/console/TilesetPyramide.java
+++ b/src/main/java/org/osm2world/console/TilesetPyramide.java
@@ -1,0 +1,371 @@
+package org.osm2world.console;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.locationtech.jts.util.Assert;
+import org.osm2world.core.target.gltf.tiles_data.TilesetAsset;
+import org.osm2world.core.target.gltf.tiles_data.TilesetEntry;
+import org.osm2world.core.target.gltf.tiles_data.TilesetParentEntry;
+import org.osm2world.core.target.gltf.tiles_data.TilesetRoot;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class TilesetPyramide {
+
+    private static final class TilesetTreeBuilder {
+
+        private record FileRegionTpl(File file, double[] region, int geomErr) {
+        }
+
+        private record TileZXY(int z, int x, int y) {
+            @Override
+            public final String toString() {
+                return z + "_" + x + "_" + y;
+            }
+        }
+
+        private static double tile2lon(int x, int z) {
+            return x / Math.pow(2.0, z) * 360.0 - 180;
+        }
+    
+        private static double tile2lat(int y, int z) {
+            double n = Math.PI - (2.0 * Math.PI * y) / Math.pow(2.0, z);
+            return Math.toDegrees(Math.atan(Math.sinh(n)));
+        }
+
+        public static int[] getTileNumber(final double lat, final double lon, final int zoom) {
+            int xtile = (int) Math.floor((lon + 180) / 360 * (1 << zoom));
+            int ytile = (int) Math
+                    .floor((1 - Math.log(Math.tan(Math.toRadians(lat)) + 1 / Math.cos(Math.toRadians(lat))) / Math.PI) / 2
+                            * (1 << zoom));
+            if (xtile < 0)
+                xtile = 0;
+            if (xtile >= (1 << zoom))
+                xtile = ((1 << zoom) - 1);
+            if (ytile < 0)
+                ytile = 0;
+            if (ytile >= (1 << zoom))
+                ytile = ((1 << zoom) - 1);
+
+            return new int[] {zoom, xtile, ytile};
+        }
+
+        public static double[] extendRegion(double[] a, double[] b) {
+            
+            double west = Math.min(a[0], b[0]);
+            double south = Math.min(a[1], b[1]);
+            
+            double east = Math.max(a[2], b[2]);
+            double north = Math.max(a[3], b[3]);
+
+            double minh = Math.min(a[4], b[4]);
+            double maxh = Math.max(a[5], b[5]);
+
+            return new double[] {
+                west, south, east, north, minh, maxh
+            };
+        }
+
+        private File outDir;
+        private List<File> tilesetFiles;
+        private String regexPattern;
+        private int srcLevel = 14;
+
+        public TilesetTreeBuilder(File outDir, int srcLevel, List<File> tilesetFiles, String pathPattern) {
+            this.outDir = outDir;
+            this.srcLevel = srcLevel;
+            this.tilesetFiles = tilesetFiles;
+            this.regexPattern = pathPattern.replaceAll("\\{z\\}", "(?<z>[0-9]+)");
+            this.regexPattern = this.regexPattern.replaceAll("\\{x\\}", "(?<x>[0-9]+)");
+            this.regexPattern = this.regexPattern.replaceAll("\\{y\\}", "(?<y>[0-9]+)");
+        }
+        
+        public void build() {
+            System.out.println("Build tileset tree for " + this.tilesetFiles.size() + " tileset files");
+
+            Pattern pattern = Pattern.compile(this.regexPattern, Pattern.CASE_INSENSITIVE);
+            
+            Map<TileZXY, List<File>> buckets16 = new HashMap<>();
+
+            this.tilesetFiles.stream().forEach(f -> {
+                Matcher m = pattern.matcher(f.toString());
+                if (m.matches()) {
+                    String zs = m.group("z");
+                    String xs = m.group("x");
+                    String ys = m.group("y");
+                
+                    if (xs != null && ys != null && zs != null) {
+                        int x = Integer.valueOf(xs);
+                        int y = Integer.valueOf(ys);
+                        int z = Integer.valueOf(zs);
+
+                        if (z == this.srcLevel) {
+                            TileZXY key16 = getParentZXY(new TileZXY(z, x, y), 2);
+    
+                            Assert.equals(key16.z, z - 2, "Unexpected z value " + f.toString());
+                            
+                            if (buckets16.get(key16) == null) {
+                                buckets16.put(key16, new ArrayList<>(16));
+                            }
+    
+                            buckets16.get(key16).add(f);
+                        }
+                    }
+                }
+                
+            });
+
+            Gson gson = new GsonBuilder().create();
+            
+            Map<TileZXY, List<FileRegionTpl>> metaTilesetBuckets = new HashMap<>();
+
+            buckets16.forEach((TileZXY bucketZXY, List<File> tiles) -> {
+
+                try {
+                    TilesetRoot parentTileSet = createEmbeddedChildrenTileset(tiles);
+
+                    File parentTileJsonFile = new File(outDir, bucketZXY.toString() + ".tileset.json");
+                    FileUtils.write(parentTileJsonFile, gson.toJson(parentTileSet));
+
+                    TileZXY parentZXY = getParentZXY(bucketZXY, 3);
+                    Assert.equals(bucketZXY.z - 3, parentZXY.z, "Unexpected z value for " + bucketZXY.toString());
+                    
+                    if (metaTilesetBuckets.get(parentZXY) == null) {
+                        metaTilesetBuckets.put(parentZXY, new ArrayList<>(64));
+                    }
+
+                    metaTilesetBuckets.get(parentZXY).add(new FileRegionTpl(
+                        parentTileJsonFile,
+                        parentTileSet.getRoot().getBoundingVolume().getRegion(),
+                        parentTileSet.getRoot().getGeometricError().intValue()));
+                    
+                }
+                catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+            
+            System.out.println(
+                this.tilesetFiles.size() +
+                " tilesets were embedded into " +
+                buckets16.size() +
+                " level 2 tilesets and written to " +
+                outDir.toString() + "/" +
+                buckets16.keySet().iterator().next().z + "_*_*.tileset.json");
+
+            Map<TileZXY, List<FileRegionTpl>> subtreeTilesets = generateTreeLevel(metaTilesetBuckets);
+            System.out.println(
+                metaTilesetBuckets.size() +
+                " level 3 tilesets written to " +
+                outDir.toString() + "/" +
+                metaTilesetBuckets.keySet().iterator().next().z + "_*_*.tileset.json");
+            
+            int total = subtreeTilesets.entrySet().stream().map(e -> e.getValue()).collect(Collectors.summingInt(List::size));
+
+            while (total > Math.pow(4, 3)) {
+                System.out.println("Generate tree over " + subtreeTilesets.size() + " subtree tilesets");
+                subtreeTilesets = generateTreeLevel(subtreeTilesets);
+            }
+
+            List<FileRegionTpl> rootTiles = subtreeTilesets.values().stream().flatMap(List::stream).collect(Collectors.toList());
+            TilesetRoot rootTileset = createParentTilesetForBucket(rootTiles, "REPLACE");
+
+            File rootTilesetFile = new File(outDir, "root.tileset.json");
+            try {
+                FileUtils.write(rootTilesetFile, gson.toJson(rootTileset));
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            System.out.println("Root tileset file: " + rootTilesetFile.toString());
+        }
+
+        /**
+         * For Files in list create parent tileset, conetents of
+         * children tiles will be embedded into parent tileset
+         */
+        private TilesetRoot createEmbeddedChildrenTileset(List<File> childrenFiles) throws IOException {
+            // TODO: Add option for deleting embedded files
+            Gson gson = new GsonBuilder().create();
+
+            TilesetRoot parentTileSet = new TilesetRoot();
+            parentTileSet.setAsset(new TilesetAsset("1.0"));
+            TilesetParentEntry parent = new TilesetParentEntry();
+
+            parentTileSet.setRoot(parent);
+
+            for (File f : childrenFiles) {
+                String tileJson = FileUtils.readFileToString(f);
+                TilesetRoot tileset = gson.fromJson(tileJson, TilesetRoot.class);
+
+                TilesetParentEntry child = tileset.getRoot();
+                parent.setGeometricError(child.getGeometricError().intValue() * 16);
+
+                parent.addChild(child);
+
+                if (parent.getBoundingVolume() == null) {
+                    parent.setBoundingVolume(child.getBoundingVolume());
+                }
+                else {
+                    double[] parentRegion = extendRegion(
+                        parent.getBoundingVolume().getRegion(),
+                        child.getBoundingVolume().getRegion());
+
+                    parent.setBoundingVolume(parentRegion);
+                }
+            }
+
+            return parentTileSet;
+        }
+
+        private static TileZXY getParentZXY(TileZXY zxy, int levels) {
+            double lat = tile2lat(zxy.y, zxy.z);
+            double lon = tile2lon(zxy.x, zxy.z);
+
+            // 64 subtile
+            int[] parentZXY = getTileNumber(lat, lon, Math.max(zxy.z - levels, 0));
+            return new TileZXY(parentZXY[0], parentZXY[1], parentZXY[2]);
+        }
+
+        private Map<TileZXY, List<FileRegionTpl>> generateTreeLevel(Map<TileZXY, List<FileRegionTpl>> currentLayerBuckets) {
+            Map<TileZXY, List<FileRegionTpl>> parentTiles = new HashMap<>();
+
+            currentLayerBuckets.forEach((TileZXY bucketZXY, List<FileRegionTpl> tilesData) -> {
+
+                TilesetRoot bucketTileSet = createParentTilesetForBucket(tilesData, "ADD");
+
+                Gson gson = new GsonBuilder().create();
+
+                String filename = bucketZXY.toString() + ".tileset.json";
+                File bucketTilesetFile = new File(outDir, filename);
+                try {
+                    FileUtils.write(bucketTilesetFile, gson.toJson(bucketTileSet));
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                TileZXY parentBucketZXY = getParentZXY(bucketZXY, 3);
+
+                if (parentTiles.get(parentBucketZXY) == null) {
+                    parentTiles.put(parentBucketZXY, new ArrayList<>());
+                }
+                parentTiles.get(parentBucketZXY).add(new FileRegionTpl(
+                    bucketTilesetFile,
+                    bucketTileSet.getRoot().getBoundingVolume().getRegion(),
+                    bucketTileSet.getRoot().getGeometricError().intValue())
+                );
+            });
+            
+            return parentTiles;
+        }
+
+        private TilesetRoot createParentTilesetForBucket(List<FileRegionTpl> tilesData, String refine) {
+            TilesetRoot bucketTileSet = new TilesetRoot();
+            bucketTileSet.setAsset(new TilesetAsset("1.0"));
+            TilesetParentEntry parent = new TilesetParentEntry();
+            parent.setRefine(refine);
+
+            bucketTileSet.setRoot(parent);
+
+            for (FileRegionTpl tileData: tilesData) {
+                TilesetEntry child = new TilesetEntry();
+                child.setGeometricError(tileData.geomErr);
+                child.setBoundingVolume(tileData.region);
+                child.setContent(tileData.file.getName());
+
+                parent.setGeometricError(tileData.geomErr * 4);
+
+                parent.addChild(child);
+
+                if (parent.getBoundingVolume() == null) {
+                    parent.setBoundingVolume(child.getBoundingVolume());
+                }
+                else {
+                    double[] parentRegion = extendRegion(
+                        parent.getBoundingVolume().getRegion(),
+                        child.getBoundingVolume().getRegion());
+
+                    parent.setBoundingVolume(parentRegion);
+                }
+            }
+
+            return bucketTileSet;
+        }
+    }
+
+    public static void main(String[] args) {
+        String pathPattern = args[0];
+        String[] pathEntries = pathPattern.split("[/\\\\]");
+
+        File base = null;
+        List<String> templates = new ArrayList<>();
+
+        for (String p : pathEntries) {
+            if (templates.isEmpty() && !isTemplated(p)) {
+                base = base == null ? new File(p) : new File(base, p);
+            }
+            else {
+                templates.add(p);
+            }
+        }
+
+        List<File> tilesets = new ArrayList<>();
+        
+        List<File> files = new ArrayList<>();
+        files.add(base);
+
+        for (String template : templates) {
+            String pattern = template.replace("{z}", "([0-9]+)");
+            pattern = pattern.replace("{x}", "([0-9]+)");
+            pattern = pattern.replace("{y}", "([0-9]+)");
+
+            System.out.println("Checking for " + pattern);
+
+            Pattern regex = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+
+            List<File> dirs = new ArrayList<>();
+
+            for (File parentf : files) {
+                
+                File[] matched = parentf.listFiles(new FileFilter() {
+        
+                    @Override
+                    public boolean accept(File pathname) {
+                        return regex.matcher(pathname.getName()).matches();
+                    }
+                    
+                });
+
+                Arrays.stream(matched)
+                    .filter(f -> f.isDirectory()).forEach(dirs::add);
+
+                Arrays.stream(matched)
+                    .filter(f -> !f.isDirectory()).forEach(tilesets::add);
+            }
+
+            files = dirs;
+        }
+
+        TilesetTreeBuilder builder = new TilesetTreeBuilder(base, 14, tilesets, pathPattern);
+        builder.build();
+    }
+
+    private static boolean isTemplated(String p) {
+        return p.contains("{z}") || p.contains("{x}") || p.contains("{y}");
+    }
+    
+}

--- a/src/main/java/org/osm2world/core/ConversionFacade.java
+++ b/src/main/java/org/osm2world/core/ConversionFacade.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -89,34 +90,42 @@ public class ConversionFacade {
 
 	/**
 	 * generates a default list of modules for the conversion
+	 * @param config 
 	 */
-	static final List<WorldModule> createDefaultModuleList() {
+	static final List<WorldModule> createDefaultModuleList(Configuration config) {
 
-		return Arrays.asList((WorldModule)
-				new RoadModule(),
-				new RailwayModule(),
-				new AerowayModule(),
-				new BuildingModule(),
-				new ParkingModule(),
-				new TreeModule(),
-				new StreetFurnitureModule(),
-				new TrafficSignModule(),
-				new BicycleParkingModule(),
-				new WaterModule(),
-				new PoolModule(),
-				new GolfModule(),
-				new SportsModule(),
-				new CliffModule(),
-				new BarrierModule(),
-				new PowerModule(),
-				new MastModule(),
-				new BridgeModule(),
-				new TunnelModule(),
-				new SurfaceAreaModule(),
-				new InvisibleModule(),
-				new IndoorModule()
-		);
+		List<Class<? extends WorldModule>> excludedModules = new ArrayList<>(0);
 
+		if (config.getBoolean("noSurface", false)) {
+			excludedModules.add(SurfaceAreaModule.class);
+		};
+
+		return Stream.of((WorldModule)
+			new RoadModule(),
+			new RailwayModule(),
+			new AerowayModule(),
+			new BuildingModule(),
+			new ParkingModule(),
+			new TreeModule(),
+			new StreetFurnitureModule(),
+			new TrafficSignModule(),
+			new BicycleParkingModule(),
+			new WaterModule(),
+			new PoolModule(),
+			new GolfModule(),
+			new SportsModule(),
+			new CliffModule(),
+			new BarrierModule(),
+			new PowerModule(),
+			new MastModule(),
+			new BridgeModule(),
+			new TunnelModule(),
+			new SurfaceAreaModule(),
+			new InvisibleModule(),
+			new IndoorModule()
+		)
+		.filter(m -> !excludedModules.contains(m.getClass()))
+		.toList();
 	}
 
 	private Function<LatLon, ? extends MapProjection> mapProjectionFactory = MetricMapProjection::new;
@@ -265,7 +274,7 @@ public class ConversionFacade {
 		updatePhase(Phase.REPRESENTATION);
 
 		if (worldModules == null) {
-			worldModules = createDefaultModuleList();
+			worldModules = createDefaultModuleList(config);
 		}
 
 		Materials.configureMaterials(config);

--- a/src/main/java/org/osm2world/core/target/gltf/MeshHeightAndSizeComparator.java
+++ b/src/main/java/org/osm2world/core/target/gltf/MeshHeightAndSizeComparator.java
@@ -1,0 +1,39 @@
+package org.osm2world.core.target.gltf;
+
+import java.util.Comparator;
+
+import org.osm2world.core.math.AxisAlignedRectangleXZ;
+import org.osm2world.core.target.common.MeshStore;
+import org.osm2world.core.target.common.MeshStore.MeshWithMetadata;
+import org.osm2world.core.target.gltf.GltfTarget.MinMax;
+
+final class MeshHeightAndSizeComparator implements Comparator<MeshStore.MeshWithMetadata> {
+	@Override
+	public int compare(MeshWithMetadata m1, MeshWithMetadata m2) {
+		MinMax ymm1 = new MinMax();
+		MinMax ymm2 = new MinMax();
+
+		m1.mesh().geometry.asTriangles().vertices().forEach(v -> {
+			ymm1.max = Double.max(ymm1.max, v.y);
+		});
+		
+		m2.mesh().geometry.asTriangles().vertices().forEach(v -> {
+			ymm2.max = Double.max(ymm2.max, v.y);
+		});
+
+		int h1 = (int)Math.round(ymm1.max * 2) / 2;
+		int h2 = (int)Math.round(ymm2.max * 2) / 2;
+
+		if (h2 != h1) {
+			return h2 - h1;
+		}
+
+		AxisAlignedRectangleXZ bbx1 = AxisAlignedRectangleXZ.bbox(m1.mesh().geometry.asTriangles().vertices());
+		AxisAlignedRectangleXZ bbx2 = AxisAlignedRectangleXZ.bbox(m2.mesh().geometry.asTriangles().vertices());
+
+		int d1 = (int)Math.round(bbx1.getDiameter() * 4) / 4;
+		int d2 = (int)Math.round(bbx2.getDiameter() * 4) / 4;
+
+		return d2 - d1;
+	}
+}

--- a/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetAsset.java
+++ b/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetAsset.java
@@ -1,0 +1,22 @@
+package org.osm2world.core.target.gltf.tiles_data;
+
+public class TilesetAsset {
+    private String version = "1.0";
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public TilesetAsset() {
+
+    }
+
+    public TilesetAsset(String version) {
+        this.version = version;
+    }
+    
+}

--- a/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetEntry.java
+++ b/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetEntry.java
@@ -1,0 +1,114 @@
+package org.osm2world.core.target.gltf.tiles_data;
+
+
+/**
+ * // Example tileset
+    "content": {
+        "uri": "14_5298_5916_0.glb"
+    },
+    "refine": "ADD",
+    "geometricError": 25,
+    "boundingVolume": {
+        "region": [-1.1098350999480917,0.7790694465970149,-1.1094516048185785,0.779342292568195,0.0,100]
+    },
+    "transform": [
+        0.895540041198885,    0.4449809373551852,  0.0,                0.0,
+        -0.31269461895546163, 0.6293090971636892,  0.7114718093525005, 0.0,
+        0.3165913926274654,   -0.6371514934593837, 0.7027146394495273, 0.0,
+        2022609.150078308,    -4070573.2078238726, 4459382.83869308,   1.0
+    ],
+
+    // This TilesetEntry covers children entries
+    "children": [{
+        "boundingVolume": {
+            "region": [-1.1098350999480917,0.7790694465970149,-1.1094516048185785,0.779342292568195,0.0,97.49999999999997]
+        },
+        "geometricError": 0,
+        "content": {
+            "uri": "14_5298_5916.glb"
+        }
+    }]
+ */
+
+
+public class TilesetEntry {
+
+    public static final class Region {
+
+        private double[] region = new double[6];
+
+        public Region() {
+        }
+
+        public Region(double[] region) {
+            this.region = region;
+        }
+
+        public double[] getRegion() {
+            return region;
+        }
+
+        public void setRegion(double[] region) {
+            this.region = region;
+        }
+    }
+
+    public static final class TilesetContent {
+        private String uri;
+
+        public TilesetContent(String uri) {
+            this.uri = uri;
+        }
+
+        public TilesetContent() {
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+    }
+
+    private Number geometricError = 0;
+    private Region boundingVolume = null;
+    private TilesetContent content = null;
+
+    public TilesetEntry() {
+    }
+
+    public TilesetEntry(Number geometricError, double[] boundingVolume, String contentUri) {
+        this.geometricError = geometricError;
+        this.boundingVolume = new Region(boundingVolume);
+        this.content = new TilesetContent(contentUri);
+    }
+
+    public Number getGeometricError() {
+        return geometricError;
+    }
+    public void setGeometricError(Number geometricError) {
+        this.geometricError = geometricError;
+    }
+    
+    public Region getBoundingVolume() {
+        return boundingVolume;
+    }
+    public void setBoundingVolume(Region boundingVolume) {
+        this.boundingVolume = boundingVolume;
+    }
+    public void setBoundingVolume(double[] region) {
+        this.boundingVolume = new Region(region);
+    }
+    
+    public TilesetContent getContent() {
+        return content;
+    }
+    public void setContent(TilesetContent content) {
+        this.content = content;
+    }
+    public void setContent(String contentUri) {
+        this.content = new TilesetContent(contentUri);
+    }
+}

--- a/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetParentEntry.java
+++ b/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetParentEntry.java
@@ -1,0 +1,79 @@
+package org.osm2world.core.target.gltf.tiles_data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * // Example tileset
+    "content": {
+        "uri": "14_5298_5916_0.glb"
+    },
+    "refine": "ADD",
+    "geometricError": 25,
+    "boundingVolume": {
+        "region": [-1.1098350999480917,0.7790694465970149,-1.1094516048185785,0.779342292568195,0.0,100]
+    },
+    "transform": [
+        0.895540041198885,    0.4449809373551852,  0.0,                0.0,
+        -0.31269461895546163, 0.6293090971636892,  0.7114718093525005, 0.0,
+        0.3165913926274654,   -0.6371514934593837, 0.7027146394495273, 0.0,
+        2022609.150078308,    -4070573.2078238726, 4459382.83869308,   1.0
+    ],
+
+    "children": [{
+        "boundingVolume": {
+            "region": [-1.1098350999480917,0.7790694465970149,-1.1094516048185785,0.779342292568195,0.0,97.49999999999997]
+        },
+        "geometricError": 0,
+        "content": {
+            "uri": "14_5298_5916.glb"
+        }
+    }]
+ */
+public class TilesetParentEntry extends TilesetEntry {
+
+    private String refine = "ADD";
+    private double[] transform;
+    private List<TilesetEntry> children;
+
+    public TilesetParentEntry() {
+    }
+
+    public String getRefine() {
+        return refine;
+    }
+    public void setRefine(String refine) {
+        this.refine = refine;
+    }
+    
+    public double[] getTransform() {
+        return transform;
+    }
+    public void setTransform(double[] transform) {
+        this.transform = transform;
+    }
+    
+    public List<TilesetEntry> getChildren() {
+        return children;
+    }
+    public void setChildren(List<TilesetEntry> children) {
+        this.children = children;
+    }
+
+    public void addChild(TilesetEntry chld) {
+        if (this.children == null) {
+            this.children = new ArrayList<>();
+        }
+        this.children.add(chld);
+    }
+    
+    public void addChild(String contentUri) {
+        this.addChild(new TilesetEntry(
+            0,
+            this.getBoundingVolume().getRegion(),
+            contentUri
+        ));
+        
+    }
+
+}

--- a/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetRoot.java
+++ b/src/main/java/org/osm2world/core/target/gltf/tiles_data/TilesetRoot.java
@@ -1,0 +1,24 @@
+package org.osm2world.core.target.gltf.tiles_data;
+
+public class TilesetRoot {
+    private TilesetAsset asset;
+    private TilesetParentEntry root;
+
+    public TilesetRoot() {
+    }
+
+    public TilesetAsset getAsset() {
+        return asset;
+    }
+    public void setAsset(TilesetAsset asset) {
+        this.asset = asset;
+    }
+    
+    public TilesetParentEntry getRoot() {
+        return root;
+    }
+    public void setRoot(TilesetParentEntry root) {
+        this.root = root;
+    }
+    
+}

--- a/src/main/java/org/osm2world/viewer/control/actions/ExportGltfAction.java
+++ b/src/main/java/org/osm2world/viewer/control/actions/ExportGltfAction.java
@@ -1,14 +1,15 @@
 package org.osm2world.viewer.control.actions;
 
-import java.awt.*;
+import java.awt.HeadlessException;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.Serial;
 import java.util.Locale;
 
-import javax.swing.*;
+import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
+import org.osm2world.core.ConversionFacade.Results;
 import org.osm2world.core.target.TargetUtil;
 import org.osm2world.core.target.TargetUtil.Compression;
 import org.osm2world.core.target.gltf.GltfTarget;
@@ -46,12 +47,17 @@ public class ExportGltfAction extends AbstractExportAction {
 
 		try {
 
-			boolean underground = data.getConfig() == null || data.getConfig().getBoolean("renderUnderground", true);
+			boolean underground = data.getConfig() == null ||
+				data.getConfig().getBoolean("renderUnderground", true);
+
+			Results conversionResults = data.getConversionResults();
 
 			/* write the file */
-			GltfTarget gltfTarget = new GltfTarget(file, flavor, Compression.NONE,null);
+			GltfTarget gltfTarget = new GltfTarget(file, flavor, Compression.NONE, conversionResults.getMapProjection(), null);
 			gltfTarget.setConfiguration(data.getConfig());
-			TargetUtil.renderWorldObjects(gltfTarget, data.getConversionResults().getMapData(), underground);
+
+			TargetUtil.renderWorldObjects(gltfTarget, conversionResults.getMapData(), underground);
+			
 			gltfTarget.finish();
 
 			messageManager.addMessage("exported glTF file " + file);


### PR DESCRIPTION
This is a draft PR

# Available configuration options

* `writeTilesetJson` adds `<out-file>.tileset.json` for *gltf* output with region and transform
* `subdivideTiles` outputs 2 gltf files, `<out-file>` with top 100 biggest meshes and `<out-file>_0` with the rest of meshes

There is also `console.TilesetPyramide` class for generation of tileset trees out of `*.tileset.json` files

# TODO

* Account for separate location for `*.tileset.json` files, as well as for different web roots
* Allow to subdivide tiles further (mb add one more level), account for `geometricError`
* Make number of meshes in subdivisions configurable
* Make spatial subdivision (subdivide tiles as quad tree first, then further subdivide by mesh type and buildings size)
